### PR TITLE
Item 'effect' field bug

### DIFF
--- a/cassiopeia/type/core/staticdata.py
+++ b/cassiopeia/type/core/staticdata.py
@@ -117,7 +117,7 @@ class Item(cassiopeia.type.core.common.CassiopeiaObject):
         Returns:
             dict<str, bool>: the item's effects
         """
-        return self.effect
+        return self.data.effect
 
     @property
     def components(self):


### PR DESCRIPTION
Fixed bug with infinite recursion while accessing 'effect' field on item