### PR TITLE
add TEAM_BUILDER_RANKED_SOLO queue type

### DIFF
--- a/cassiopeia/type/core/common.py
+++ b/cassiopeia/type/core/common.py
@@ -226,8 +226,10 @@ class Queue(enum.Enum):
     random_urf = "ARURF_5X5"
     dynamic_queue = "TEAM_BUILDER_DRAFT_UNRANKED_5x5"
     ranked_dynamic_queue = "TEAM_BUILDER_DRAFT_RANKED_5x5"
+    ranked_solo_queue = "TEAM_BUILDER_RANKED_SOLO"
     flex = "RANKED_FLEX_SR"
     flex_threes = "RANKED_FLEX_TT"
+
 
     def for_id(id_):
         try:
@@ -277,9 +279,10 @@ Queue.by_id = {
     318: Queue.random_urf,
     400: Queue.dynamic_queue,
     410: Queue.ranked_dynamic_queue,
+    420: Queue.ranked_solo_queue,
     440: Queue.flex
 }
-ranked_queues = {Queue.ranked_solo, Queue.ranked_threes, Queue.ranked_fives, Queue.ranked_dynamic_queue, Queue.flex, Queue.flex_threes}
+ranked_queues = {Queue.ranked_solo, Queue.ranked_threes, Queue.ranked_fives, Queue.ranked_dynamic_queue, Queue.flex, Queue.flex_threes, Queue.ranked_solo_queue}
 
 
 class Tier(enum.Enum):


### PR DESCRIPTION
solves #85 

according to https://developer.riotgames.com/docs/game-constants, i added the TEAM_BUILDER_RANKED_SOLO, with id 420

Please advise on the abstracted queue name (ranked_solo_queue) which is almost same as previous ranked_solo (now deprecated)