### PR TITLE
Add Sqlite Support

### DIFF
--- a/cassiopeia/type/api/store.py
+++ b/cassiopeia/type/api/store.py
@@ -236,7 +236,10 @@ if cassiopeia.type.dto.common.sqlalchemy_imported:
                 complete_sets (list<type>): include any types for which it should be marked that all possible values are stored
             """
             _sa_bind_typesystem()
-            self.db = sqlalchemy.create_engine("{flavor}://{username}:{password}@{host}/{database}".format(flavor=flavor, host=host, database=database, username=username, password=password))
+            if flavor == 'sqlite':
+                self.db = sqlalchemy.create_engine("{flavor}://{database}".format(flavor=flavor, database=database))
+            else:
+                self.db = sqlalchemy.create_engine("{flavor}://{username}:{password}@{host}/{database}".format(flavor=flavor, host=host, database=database, username=username, password=password))
             cassiopeia.type.dto.common.BaseDB.metadata.create_all(self.db)
             self.session = sqlalchemy.orm.sessionmaker(bind=self.db)()
 


### PR DESCRIPTION
Adds support for sqlite by adding an exception for the [SQLAlchemy `create_engine` syntax](http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlite) for it.

Closes #66.

```python
# Specify DB by relative path
db = SQLAlchemyDB("sqlite", "", "/cass.db", "", "")

# Specify DB by absolute path
db = SQLAlchemyDB("sqlite", "", "//path/to/cass.db", "", "")

# Use an in-memory DB
db = SQLAlchemyDB("sqlite", "", "", "", "")
```

I tested by using `examples/match_collection.py`, changing the database line:
```python
# L79
 db = SQLAlchemyDB("sqlite", "", "/matches.db", "", "")
```

![screen shot 2017-04-20 at 8 02 26 pm](https://cloud.githubusercontent.com/assets/610242/25257256/bd1d2128-2604-11e7-9f96-76bcacce11ff.png)

I then tested using MySQL:

```
db = SQLAlchemyDB("mysql+pymysql", "localhost", "test", "root", "")
```

```
mysql> select * from summoner;
+----------+------------------+---------------+---------------+---------------+
| id       | name             | profileIconId | revisionDate  | summonerLevel |
+----------+------------------+---------------+---------------+---------------+
|    89197 | Diamond 1 Player |           983 | 1492472793000 |            30 |
| 19451735 | hommedeplumme    |           512 | 1492688859000 |            30 |
| 19732914 | Liquid Ezra      |          1020 | 1492728362000 |            30 |
| 20078731 | TdollasAKATmoney |           517 | 1492717568000 |            30 |
| 20082683 | Quantum Fizzics  |          1455 | 1492674479000 |            30 |
| 20577176 | ooo la la        |           572 | 1491935199000 |            30 |
| 21063764 | Fiftygbl         |            23 | 1492707241000 |            30 |
| 21202019 | 5fire            |           539 | 1492727272000 |            30 |
| 22447403 | PrismaI          |          1627 | 1492738225000 |            30 |
| 29533033 | PandaTv 656826   |          1427 | 1492725655000 |            30 |
| 30307001 | Turc             |             7 | 1492706182000 |            30 |
| 31027710 | Feather Daddy    |           661 | 1492737354000 |            30 |
| 34042136 | Sayonaraaaaa     |           508 | 1492738225000 |            30 |
| 35703236 | PieCakeLord      |           753 | 1492738161000 |            30 |
| 36447212 | AsianSGpøtatø    |          1114 | 1492722987000 |            30 |
| 45675133 | GrayHoves        |          1535 | 1492738105000 |            30 |
| 46531569 | iKingVex         |           581 | 1492727569000 |            30 |
| 59609209 | LTF Cathedral    |          1392 | 1492726436000 |            30 |
| 60946315 | 4396 Lobster     |             7 | 1492706859000 |            30 |
| 68301925 | LCS Actor 4      |          1464 | 1492726069000 |            30 |
| 69653316 | DIG Swifte       |          1461 | 1492388487000 |            30 |
| 73459347 | LKN              |             7 | 1492049947000 |            30 |
| 75290273 | Corsair Dekar    |             0 | 1492685095000 |            30 |
| 76051169 | BamBooGod        |          1429 | 1492738225000 |            30 |
| 79420232 | FOX Akaadian     |          1462 | 1492737245000 |            30 |
| 83669295 | JPT              |           911 | 1492141260000 |            30 |
+----------+------------------+---------------+---------------+---------------+
26 rows in set (0.00 sec)
```