### PR TITLE
Add new Dark Star game mode enums.

### DIFF
--- a/cassiopeia/type/core/common.py
+++ b/cassiopeia/type/core/common.py
@@ -369,6 +369,7 @@ class GameMode(enum.Enum):
     tutorial = "TUTORIAL"
     nexus_siege = "SIEGE"
     assassinate = "ASSASSINATE"
+    dark_star = "DARKSTAR"
 
 
 class GameType(enum.Enum):

--- a/cassiopeia/type/core/common.py
+++ b/cassiopeia/type/core/common.py
@@ -355,6 +355,7 @@ class Map(enum.Enum):
     summoners_rift = 11
     howling_abyss = 12
     butchers_bridge = 14
+    cosmic_ruins = 16
 
 
 class GameMode(enum.Enum):


### PR DESCRIPTION
Fixes `ValueError: 16 is not a valid Map` and `ValueError: 'DARKSTAR' is not a valid GameMode`