### PR TITLE
Fixes #124

### DIFF
--- a/cassiopeia/core/spectator.py
+++ b/cassiopeia/core/spectator.py
@@ -359,7 +359,7 @@ class CurrentMatch(CassiopeiaGhost):
     @CassiopeiaGhost.property(CurrentGameInfoData)
     @ghost_load_on(KeyError)
     def duration(self) -> datetime.datetime:
-        return datetime.datetime.fromtimestamp(self._data[CurrentGameInfoData].duration / 1000)
+        return datetime.timedelta(seconds=self._data[CurrentGameInfoData].duration)
 
     @CassiopeiaGhost.property(CurrentGameInfoData)
     @ghost_load_on(KeyError)


### PR DESCRIPTION
`duration` is not a timestamp, and should be handled with `timedelta` rather than `fromtimestamp`.