### PR TITLE
Added default decoding to UTF-8

### DIFF
--- a/cassiopeia/datastores/common.py
+++ b/cassiopeia/datastores/common.py
@@ -111,15 +111,16 @@ class HTTPClient(object):
 
         content_type = response_headers.get("Content-Type", "application/octet-stream").upper()
 
-        # Decode to text if a charset is included
-        match = re.search("CHARSET=(\S+)", content_type)
-        if match:
-            encoding = match.group(1)
+        # Load JSON if necessary
+        if "APPLICATION/JSON" in content_type:
+            # Decode to text; use charset if included
+            match = re.search("CHARSET=(\S+)", content_type)
+            if match:
+                encoding = match.group(1)
+            else:
+                encoding = "UTF-8"
             body = body.decode(encoding)
-
-            # Load JSON if necessary
-            if "APPLICATION/JSON" in content_type:
-                body = json.loads(body)
+            body = json.loads(body)
 
         # Handle errors
         if status_code >= 400:

--- a/cassiopeia/datastores/ddragon.py
+++ b/cassiopeia/datastores/ddragon.py
@@ -117,7 +117,7 @@ class DDragon(DataSource):
             locale=locale
         )
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 
@@ -191,7 +191,7 @@ class DDragon(DataSource):
     def get_versions(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> VersionListDto:
         url = "https://ddragon.leagueoflegends.com/api/versions.json"
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 
@@ -213,7 +213,7 @@ class DDragon(DataSource):
         region = query["platform"].region
         url = "https://ddragon.leagueoflegends.com/realms/{region}.json".format(region=region.value.lower())
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
 
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
@@ -233,7 +233,7 @@ class DDragon(DataSource):
     def get_languages(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> LanguagesDto:
         url = "https://ddragon.leagueoflegends.com/cdn/languages.json"
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 
@@ -303,7 +303,7 @@ class DDragon(DataSource):
             locale=locale
         )
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 
@@ -337,7 +337,7 @@ class DDragon(DataSource):
             locale=locale
         )
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 
@@ -412,7 +412,7 @@ class DDragon(DataSource):
             locale=locale
         )
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 
@@ -511,7 +511,7 @@ class DDragon(DataSource):
             locale=locale
         )
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 
@@ -605,7 +605,7 @@ class DDragon(DataSource):
             locale=locale
         )
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 
@@ -706,7 +706,7 @@ class DDragon(DataSource):
             locale=locale
         )
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 
@@ -749,7 +749,7 @@ class DDragon(DataSource):
             locale=locale
         )
         try:
-            body = json.loads(self._client.get(url)[0])
+            body = self._client.get(url)[0]
         except HTTPError as e:
             raise NotFoundError(str(e)) from e
 

--- a/cassiopeia/transformers/staticdata.py
+++ b/cassiopeia/transformers/staticdata.py
@@ -178,14 +178,14 @@ class StaticDataTransformer(DataTransformer):
     # Profile Icons
 
     @transform.register(ProfileIconDetailsDto, ProfileIconData)
-    def profile_icon_dto_to_data(self, value: ProfileIconDetailsDto, context: PipelineContext = None) -> ProfileIconData:
+    def profile_icon_details_dto_to_data(self, value: ProfileIconDetailsDto, context: PipelineContext = None) -> ProfileIconData:
         data = deepcopy(value)
         return ProfileIconData.from_dto(data)
 
     @transform.register(ProfileIconDataDto, ProfileIconListData)
     def profile_icon_dto_to_data(self, value: ProfileIconDataDto, context: PipelineContext = None) -> ProfileIconListData:
         data = deepcopy(value)
-        return ProfileIconListData([self.profile_icon_dto_to_data(p) for p in data["data"]], region=value["region"], version=value["version"], locale=value["locale"])
+        return ProfileIconListData([self.profile_icon_details_dto_to_data(p) for p in data["data"]], region=value["region"], version=value["version"], locale=value["locale"])
 
     ################
     # Data to Core #


### PR DESCRIPTION
Because DDragon no longer returns a Charset in the Content-Type the following error occurred:

> Making call: https://ddragon.leagueoflegends.com/realms/na.json
Traceback (most recent call last):
  File "/home/anton/workspace/cassio-testing/env/lib/python3.5/site-packages/datapipelines/sources.py", line 69, in wrapper
    return call(self, query, context=context)
  File "/home/anton/workspace/cassio-testing/env/lib/python3.5/site-packages/datapipelines/queries.py", line 323, in wrapped
    return method(self, query, context)
  File "/home/anton/workspace/cassio-testing/env/lib/python3.5/site-packages/cassiopeia/datastores/ddragon.py", line 216, in get_realms
    body = json.loads(self._client.get(url)[0])
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'

This happens because the returned body no longer got decoded to a string because of that missing charset.
That's why i added default decoding (UTF-8) if the Content-Type is application/json
