### PR TITLE
Added 'tokens' property to 'ChampionMastery' class.

### DIFF
--- a/cassiopeia/core/championmastery.py
+++ b/cassiopeia/core/championmastery.py
@@ -24,7 +24,7 @@ class ChampionMasteryListData(CoreDataList):
 
 class ChampionMasteryData(CoreData):
     _dto_type = ChampionMasteryDto
-    _renamed = {"championLevel": "level", "championPoints": "points", "playerId": "summonerId", "championPointsUntilNextLevel": "pointsUntilNextLevel", "championPointsSinceLastLevel": "pointsSinceLastLevel", "lastPlayTime": "lastPlayed"}
+    _renamed = {"championLevel": "level", "championPoints": "points", "playerId": "summonerId", "championPointsUntilNextLevel": "pointsUntilNextLevel", "championPointsSinceLastLevel": "pointsSinceLastLevel", "lastPlayTime": "lastPlayed", "tokensEarned": "tokens"}
 
 
 ##############
@@ -130,6 +130,7 @@ class ChampionMastery(CassiopeiaGhost):
                 "chestGranted": False,
                 "championPoints": 0,
                 "championPointsUntilNextLevel": 1800,
+                "tokensEarned": 0,
                 "championPointsSinceLastLevel": 0,
                 "lastPlayTime": None
             }
@@ -186,6 +187,12 @@ class ChampionMastery(CassiopeiaGhost):
     def points_until_next_level(self) -> int:
         """Number of points needed to achieve next level. Zero if player reached maximum champion level for this champion."""
         return self._data[ChampionMasteryData].pointsUntilNextLevel
+
+    @CassiopeiaGhost.property(ChampionMasteryData)
+    @ghost_load_on
+    def tokens(self) -> int:
+        """Number of tokens earned toward next mastery level."""
+        return self._data[ChampionMasteryData].tokens
 
     @CassiopeiaGhost.property(ChampionMasteryData)
     @ghost_load_on


### PR DESCRIPTION
For some reason, accessing the number of champion mastery tokens you've got on a champion was not possible in the same way you'd access any other property returned from the champion mastery endpoint on the Riot API.
From the limited testing I've done (read: the one snippet I've included below), my changes seem to work as intended. (Your decorators are awesome!)
```Python
import cassiopeia as cass

cass.set_riot_api_key('<key>')
cass.set_default_region('EUW')

summoner = cass.get_summoner(name='Zurkrem')
champion_masteries = summoner.champion_masteries

numbr7 = champion_masteries[7]
print('{name} has {tokens} tokens on {champion} towards level {next_level}.'.format(name=summoner.name,
                                                                                    tokens=numbr7.tokens,
                                                                                    champion=numbr7.champion.name,
                                                                                    next_level=numbr7.level+1))
```

The above code prints out: `Zurkrem has 2 tokens on Ahri towards level 7.`
  