### PR TITLE
Fixed a bug for static data passive images

### DIFF
--- a/cassiopeia/core/staticdata/champion.py
+++ b/cassiopeia/core/staticdata/champion.py
@@ -78,7 +78,7 @@ class PassiveData(CoreData):
 
     def __call__(self, **kwargs):
         if "image" in kwargs:
-            self.image = ImageData(**kwargs.pop("image"))
+            self.image = ImageData(version=kwargs["version"], **kwargs.pop("image"))
         super().__call__(**kwargs)
         return self
 
@@ -111,9 +111,11 @@ class ChampionData(CoreData):
         if "skins" in kwargs:
             self.skins = [SkinData(**skin) for skin in kwargs.pop("skins")]
         if "passive" in kwargs:
-            self.passive = PassiveData(**kwargs.pop("passive"))
-        if "spells" in kwargs:
             version = kwargs.get("version", get_latest_version(kwargs["region"], endpoint="champion"))
+            self.passive = PassiveData(version=version, **kwargs.pop("passive"))
+        if "spells" in kwargs:
+            if not version:
+                version = kwargs.get("version", get_latest_version(kwargs["region"], endpoint="champion"))
             self.spells = [ChampionSpellData(version=version, **spell) for spell in kwargs.pop("spells")]
         super().__call__(**kwargs)
         return self


### PR DESCRIPTION
Bug i fixed:
```python
champ.passive.image_info.url 
```
```python  
File "D:\Python\RiftHerald\.VirtualEnv\lib\site-packages\cassiopeia\core\staticdata\common.py", line 72, in url
    return "https://ddragon.leagueoflegends.com/cdn/{version}/img/{group}/{full}".format(version=self.version, group=self.group, full=self.full)
  File "D:\Python\RiftHerald\.VirtualEnv\lib\site-packages\cassiopeia\core\staticdata\common.py", line 60, in version
    return self._data[ImageData].version
AttributeError: 'ImageData' object has no attribute 'version'
```

Why it happened:
In contorary to the normal spells, passives created the ImageData without a version. This let to image_info.url to fail, as it expects a version to create the ddragon url.

What did i do?
I added the version to the passive and added a check to not load the version information twice for passive and spells.