### PR TITLE
Change PatchSource to retrieve latest patches file

### DIFF
--- a/cassiopeia/datastores/patch.py
+++ b/cassiopeia/datastores/patch.py
@@ -35,7 +35,7 @@ class PatchSource(DataSource):
     @get.register(PatchListDto)
     def get_patch_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> PatchListDto:
         # See: https://rawgit.com/
-        url = "https://cdn.rawgit.com/CommunityDragon/Data/b033fdf7/patches.json"
+        url = "https://cdn.rawgit.com/CommunityDragon/Data/master/patches.json"
         try:
             body = self._client.get(url)[0]
         except HTTPError as e:


### PR DESCRIPTION
The source for get_patch_list is a raw json file from the [CommunityDragon/Data](https://github.com/CommunityDragon/Data) repo. Currently the file being sourced is fixed to a specific commit, so it does not get updated with new patches (and hasn't been since 8.9). By changing the source to the file on master, it will automatically retrieve the latest patch info as long as the CommunityDragon/Data repo stays updated.