### PR TITLE
Fix typo in field access, purchaseable->purchasable

### DIFF
--- a/cassiopeia/core/staticdata/item.py
+++ b/cassiopeia/core/staticdata/item.py
@@ -257,8 +257,8 @@ class Gold(CassiopeiaObject):
         return self._data[GoldData].base
 
     @property
-    def purchaseable(self) -> bool:
-        return self._data[GoldData].purchaseable
+    def purchasable(self) -> bool:
+        return self._data[GoldData].purchasable
 
 
 @searchable({str: ["name", "region", "platform", "locale", "keywords", "maps", "tags", "tier"], int: ["id"], Region: ["region"], Platform: ["platform"], Map: ["maps"]})


### PR DESCRIPTION
Fixes `AttributeError: 'GoldData' object has no attribute 'purchaseable'`

I don't think this is a breaking change because anything using this would throw an exception.