### PR TITLE
Fixes a bug with loading incorrect champions in Team.bans

### DIFF
--- a/cassiopeia/core/match.py
+++ b/cassiopeia/core/match.py
@@ -1223,7 +1223,8 @@ class Team(CassiopeiaObject):
 
     @property
     def bans(self) -> List["Champion"]:
-        return [Champion(id=champion_id, version=self.__match.version, region=self.__match.region) if champion_id != -1 else None for champion_id in self._data[TeamData].bans]
+        version = _choose_staticdata_version(self.__match)
+        return [Champion(id=champion_id, version=version, region=self.__match.region) if champion_id != -1 else None for champion_id in self._data[TeamData].bans]
 
     @property
     def baron_kills(self) -> int:


### PR DESCRIPTION
Currently there's a bug where doing something like the following:
```python
match = Match(id=MATCH_ID, region=Region.north_america)
for ban in match.blue_team.bans:
    if ban is not None:
        print(ban.image.url)
```

Calls the following incorrect URL for champion data. 
> Making call: https://ddragon.leagueoflegends.com/cdn/8.13.235.9749/data/en_US/championFull.json

This PR fixes the problem.