### PR TITLE
Update cassiopeia to v4 of the riot api

### DIFF
--- a/cassiopeia/__init__.py
+++ b/cassiopeia/__init__.py
@@ -2,9 +2,9 @@
 from ._configuration import get_default_config, Settings, CassiopeiaConfiguration as _CassiopeiaConfiguration
 configuration = _CassiopeiaConfiguration()
 
-from .cassiopeia import get_realms, get_challenger_league, get_champion_masteries, get_champion, get_champion_mastery, get_champions, get_current_match, get_featured_matches, get_items, get_language_strings, get_locales, get_league_positions, get_leagues, get_maps, get_master_league, get_match, get_match_history, get_profile_icons, get_runes, get_status, get_summoner, get_summoner_spells, get_version, get_versions, get_champion_rotations
+from .cassiopeia import get_realms, get_challenger_league, get_champion_masteries, get_champion, get_champion_mastery, get_champions, get_current_match, get_featured_matches, get_items, get_language_strings, get_locales, get_league_positions, get_leagues, get_maps, get_master_league, get_grandmaster_league, get_match, get_match_history, get_profile_icons, get_runes, get_status, get_summoner, get_summoner_spells, get_version, get_versions, get_champion_rotations
 from .cassiopeia import apply_settings, set_riot_api_key, set_default_region, print_calls
-from .core import Champion, Champions, Rune, Runes, Item, Items, SummonerSpell, SummonerSpells, ProfileIcon, ProfileIcons, Versions, Maps, Summoner, Account, ChampionMastery, ChampionMasteries, Match, FeaturedMatches, ShardStatus, ChallengerLeague, MasterLeague, Map, Realms, LanguageStrings, Locales, LeagueEntries, League, Patch, VerificationString, MatchHistory, ChampionRotation
+from .core import Champion, Champions, Rune, Runes, Item, Items, SummonerSpell, SummonerSpells, ProfileIcon, ProfileIcons, Versions, Maps, Summoner, Account, ChampionMastery, ChampionMasteries, Match, FeaturedMatches, ShardStatus, ChallengerLeague, GrandmasterLeague, MasterLeague, Map, Realms, LanguageStrings, Locales, LeagueEntries, League, Patch, VerificationString, MatchHistory, ChampionRotation
 from .data import Queue, Region, Platform, Resource, Side, GameMode, MasteryTree, RunePath, Tier, Division, Season, GameType, Lane, Role, Rank, Key, SummonersRiftArea
 
 apply_settings(configuration.settings)

--- a/cassiopeia/cassiopeia.py
+++ b/cassiopeia/cassiopeia.py
@@ -86,7 +86,7 @@ def get_champion_mastery(summoner: Summoner, champion: Union[Champion, int, str]
     return ChampionMastery(champion=champion, summoner=summoner, region=region)
 
 
-def get_summoner(*, id: int = None, account: Union[Account, int] = None, name: str = None, region: Union[Region, str] = None) -> Summoner:
+def get_summoner(*, id: str = None, account: Union[Account, str] = None, name: str = None, region: Union[Region, str] = None) -> Summoner:
     return Summoner(id=id, account=account, name=name, region=region)
 
 

--- a/cassiopeia/cassiopeia.py
+++ b/cassiopeia/cassiopeia.py
@@ -3,7 +3,7 @@ import arrow
 import datetime
 
 from .data import Region, Queue, Season
-from .core import Champion, Summoner, Account, ChampionMastery, Rune, Item, Match, Map, SummonerSpell, Realms, ProfileIcon, LanguageStrings, CurrentMatch, ShardStatus, Versions, MatchHistory, Champions, ChampionMasteries, Runes, Items, SummonerSpells, Maps, FeaturedMatches, Locales, ProfileIcons, ChallengerLeague, MasterLeague, SummonerLeagues, LeagueEntries, Patch, VerificationString, ChampionRotation
+from .core import Champion, Summoner, Account, ChampionMastery, Rune, Item, Match, Map, SummonerSpell, Realms, ProfileIcon, LanguageStrings, CurrentMatch, ShardStatus, Versions, MatchHistory, Champions, ChampionMasteries, Runes, Items, SummonerSpells, Maps, FeaturedMatches, Locales, ProfileIcons, ChallengerLeague, GrandmasterLeague, MasterLeague, SummonerLeagues, LeagueEntries, Patch, VerificationString, ChampionRotation
 from .datastores import common as _common_datastore
 from ._configuration import Settings, load_config, get_default_config
 from . import configuration
@@ -56,6 +56,8 @@ def get_leagues(summoner: Summoner, region: Union[Region, str] = None) -> Summon
 def get_master_league(queue: Union[Queue, int, str], region: Union[Region, str] = None) -> MasterLeague:
     return MasterLeague(queue=queue, region=region)
 
+def get_grandmaster_league(queue: Union[Queue, int, str], region: Union[Region, str] = None) -> GrandmasterLeague:
+    return GrandmasterLeague(queue=queue, region=region)
 
 def get_challenger_league(queue: Union[Queue, int, str], region: Union[Region, str] = None) -> ChallengerLeague:
     return ChallengerLeague(queue=queue, region=region)

--- a/cassiopeia/core/__init__.py
+++ b/cassiopeia/core/__init__.py
@@ -5,6 +5,6 @@ from .championmastery import ChampionMastery, ChampionMasteries
 from .match import Match, MatchHistory
 from .spectator import CurrentMatch, FeaturedMatches
 from .status import ShardStatus
-from .league import ChallengerLeague, MasterLeague, SummonerLeagues, LeagueEntries, League
+from .league import ChallengerLeague, GrandmasterLeague, MasterLeague, SummonerLeagues, LeagueEntries, League
 from .patch import Patch
 from .thirdpartycode import VerificationString

--- a/cassiopeia/core/championmastery.py
+++ b/cassiopeia/core/championmastery.py
@@ -48,9 +48,12 @@ class ChampionMasteries(CassiopeiaLazyList):
         if isinstance(summoner, Summoner):
             query["summoner.id"] = summoner.id
         elif isinstance(summoner, str):
-            query["summoner.id"] = Summoner(name=summoner, region=region).id
-        else:  # int
-            query["summoner.id"] = summoner
+            if len(summoner) < 35:
+                # It's a summoner name
+                query["summoner.id"] = Summoner(name=summoner, region=region).id
+            else:
+                # It's probably a summoner id
+                query["summoner.id"] = summoner
         return query
 
     @lazy_property
@@ -81,10 +84,13 @@ class ChampionMastery(CassiopeiaGhost):
             if isinstance(summoner, Summoner):
                 self.__class__.summoner.fget._lazy_set(self, summoner)
             elif isinstance(summoner, str):
-                summoner = Summoner(name=summoner, region=region)
-                self.__class__.summoner.fget._lazy_set(self, summoner)
-            else:  # int
-                kwargs["summonerId"] = summoner
+                if len(summoner) < 35:
+                    # It's a summoner name
+                    summoner = Summoner(name=summoner, region=region)
+                    self.__class__.summoner.fget._lazy_set(self, summoner)
+                else:
+                    # It's probably a summoner id
+                    kwargs["summonerId"] = summoner
 
         if champion is not None:
             if isinstance(champion, Champion):
@@ -104,9 +110,13 @@ class ChampionMastery(CassiopeiaGhost):
         if isinstance(summoner, Summoner):
             query["summoner.id"] = summoner.id
         elif isinstance(summoner, str):
-            query["summoner.id"] = Summoner(name=summoner, region=region).id
-        else:  # int
-            query["summoner.id"] = summoner
+            if len(summoner) < 35:
+                # It's a summoner name
+                query["summoner.id"] = Summoner(name=summoner, region=region).id
+            else:
+                # It's probably a summoner id
+                query["summoner.id"] = summoner
+            
 
         if isinstance(champion, Champion):
             query["champion.id"] = champion.id

--- a/cassiopeia/core/championmastery.py
+++ b/cassiopeia/core/championmastery.py
@@ -78,7 +78,7 @@ class ChampionMastery(CassiopeiaGhost):
         kwargs = {"region": region}
 
         if _account_id is not None:
-            summoner = Summoner(account=_account_id, region=region)
+            summoner = Summoner(accountId=_account_id, region=region)
 
         if summoner is not None:
             if isinstance(summoner, Summoner):

--- a/cassiopeia/core/league.py
+++ b/cassiopeia/core/league.py
@@ -202,10 +202,6 @@ class LeagueEntry(CassiopeiaGhost):
     def fresh_blood(self) -> bool:
         return self._data[LeaguePositionData].freshBlood
 
-    @property
-    def league_id(self) -> str:
-        return self._data[LeaguePositionData].leagueId
-
     @lazy_property
     def league(self) -> "League":
         return League(id=self.league_id, region=self.region)
@@ -384,10 +380,11 @@ class ChallengerLeague(CassiopeiaGhost):
     @lazy_property
     def platform(self) -> Platform:
         return self.region.platform
-
-    @property
-    def id(self) -> Tier:
-        return self._data[LeagueListData].id
+    
+    @CassiopeiaGhost.property(ChallengerLeagueListData)
+    @ghost_load_on
+    def id(self) -> str:
+        return self._data[ChallengerLeagueListData].id
 
     @lazy_property
     def tier(self) -> Tier:
@@ -446,9 +443,10 @@ class GrandmasterLeague(CassiopeiaGhost):
     def platform(self) -> Platform:
         return self.region.platform
 
-    @property
-    def id(self) -> Tier:
-        return self._data[LeagueListData].id
+    @CassiopeiaGhost.property(GrandmasterLeagueListData)
+    @ghost_load_on
+    def id(self) -> str:
+        return self._data[GrandmasterLeagueListData].id
 
     @lazy_property
     def tier(self) -> Tier:
@@ -507,9 +505,10 @@ class MasterLeague(CassiopeiaGhost):
     def platform(self) -> Platform:
         return self.region.platform
 
-    @property
-    def id(self) -> Tier:
-        return self._data[LeagueListData].id
+    @CassiopeiaGhost.property(MasterLeagueListData)
+    @ghost_load_on
+    def id(self) -> str:
+        return self._data[MasterLeagueListData].id
 
     @lazy_property
     def tier(self) -> Tier:

--- a/cassiopeia/core/league.py
+++ b/cassiopeia/core/league.py
@@ -196,7 +196,7 @@ class LeagueEntry(CassiopeiaGhost):
 
     @lazy_property
     def summoner(self) -> Summoner:
-        return Summoner(id=self._data[LeaguePositionData].summonerId, name=self._data[LeaguePositionData].summonerName, region=self.region)  # TODO I don't know why the summoner id isn't already an int; it's a string for some reason.
+        return Summoner(id=self._data[LeaguePositionData].summonerId, name=self._data[LeaguePositionData].summonerName, region=self.region)
 
     @property
     def fresh_blood(self) -> bool:
@@ -272,11 +272,6 @@ class SummonerLeagues(SearchableList):
     @property
     def threes(self):
         return self[Queue.ranked_flex_threes]
-
-    def set_queues(self, queues:{str:Queue}):
-        # Temporary hotfix method
-        for league in self:
-            league._data[LeagueListData].queue = queues[league.id]
 
 
 @searchable({str: ["tier", "queue", "name"], Queue: ["queue"], Tier: ["tier"]})

--- a/cassiopeia/core/league.py
+++ b/cassiopeia/core/league.py
@@ -273,6 +273,11 @@ class SummonerLeagues(SearchableList):
     def threes(self):
         return self[Queue.ranked_flex_threes]
 
+    def set_queues(self, queues:{str:Queue}):
+        # Temporary hotfix method
+        for league in self:
+            league._data[LeagueListData].queue = queues[league.id]
+
 
 @searchable({str: ["tier", "queue", "name"], Queue: ["queue"], Tier: ["tier"]})
 class League(CassiopeiaGhost):

--- a/cassiopeia/core/match.py
+++ b/cassiopeia/core/match.py
@@ -265,7 +265,7 @@ class MatchHistory(CassiopeiaLazyList):  # type: List[Match]
             end_time = end_time.timestamp * 1000
         kwargs["end_time"] = end_time
         assert isinstance(summoner, Summoner)
-        self.__account_id_callable = lambda: summoner.account.id
+        self.__account_id_callable = lambda: summoner.account_id
         self.__summoner = summoner
         CassiopeiaObject.__init__(self, **kwargs)
 
@@ -273,7 +273,7 @@ class MatchHistory(CassiopeiaLazyList):  # type: List[Match]
     def __get_query_from_kwargs__(cls, *, summoner: Summoner, begin_index: int = None, end_index: int = None, begin_time: arrow.Arrow = None, end_time: arrow.Arrow = None, queues: Set[Queue] = None, seasons: Set[Season] = None, champions: Set[Champion] = None):
         assert isinstance(summoner, Summoner)
         query = {"region": summoner.region}
-        query["account.id"] = summoner.account.id
+        query["accountId"] = summoner.account_id
 
         if begin_index is not None:
             query["beginIndex"] = begin_index

--- a/cassiopeia/core/spectator.py
+++ b/cassiopeia/core/spectator.py
@@ -174,37 +174,40 @@ class CurrentMatch(CassiopeiaGhost):
     _data_types = {CurrentGameInfoData}
 
     @provide_default_region
-    def __init__(self, *, summoner: Union[Summoner, int, str] = None, region: Union[Region, str] = None):
+    def __init__(self, *, summoner: Union[Summoner, str] = None, region: Union[Region, str] = None):
         kwargs = {"region": region}
 
         if summoner is not None:
             if isinstance(summoner, str):
-                summoner = Summoner(name=summoner, region=region)
-            elif isinstance(summoner, int):
-                summoner = Summoner(id=summoner, region=region)
+                if len(summoner) < 35:
+                    summoner = Summoner(name=summoner, region=region)
+                else:
+                    summoner = Summoner(id=summoner, region=region)
             self.__summoner = summoner
         super().__init__(**kwargs)
 
     @classmethod
-    def from_data(cls, data: CurrentGameInfoData, summoner: Union[Summoner, int, str]):
+    def from_data(cls, data: CurrentGameInfoData, summoner: Union[Summoner, str]):
         self = super().from_data(data)
         if isinstance(summoner, str):
-            summoner = Summoner(name=summoner, region=data.region)
-        elif isinstance(summoner, int):
-            summoner = Summoner(id=summoner, region=data.region)
-        self.__summoner = summoner
+            if len(summoner) < 35:
+                summoner = Summoner(name=summoner, region=region)
+            else:
+                summoner = Summoner(id=summoner, region=region)
+                self.__summoner = summoner
         return self
 
     @classmethod
     @provide_default_region
-    def __get_query_from_kwargs__(cls, *, summoner: Union[Summoner, int, str], region: Union[Region, str]) -> dict:
+    def __get_query_from_kwargs__(cls, *, summoner: Union[Summoner, str], region: Union[Region, str]) -> dict:
         query = {"region": region}
         if isinstance(summoner, Summoner):
             query["summoner.id"] = summoner.id
-        elif isinstance(summoner, int):  # int
-            query["summoner.id"] = summoner
         elif isinstance(summoner, str):
-            query["summoner.id"] = Summoner(name=summoner, region=region).id
+            if len(summoner) < 35:
+                query["summoner.id"] = Summoner(name=summoner, region=region).id
+            else:
+                query["summoner.id"] = summoner
         assert "summoner.id" in query
         return query
 

--- a/cassiopeia/core/summoner.py
+++ b/cassiopeia/core/summoner.py
@@ -59,7 +59,7 @@ class Summoner(CassiopeiaGhost):
     _data_types = {SummonerData}
 
     @provide_default_region
-    def __init__(self, *, id: str = None, account: Union[Account, str] = None, name: str = None, region: Union[Region, str] = None, puuid: str = None):
+    def __init__(self, *, id: str = None, account: Union[Account, str] = None, puuid: str = None, name: str = None, region: Union[Region, str] = None):
         kwargs = {"region": region}
         if id is not None:
             kwargs["id"] = id
@@ -78,7 +78,7 @@ class Summoner(CassiopeiaGhost):
 
     @classmethod
     @provide_default_region
-    def __get_query_from_kwargs__(cls, *, id: str = None, account: Union[Account, str] = None, name: str = None, region: Union[Region, str], puuid: str=None) -> dict:
+    def __get_query_from_kwargs__(cls, *, id: str = None, account: Union[Account, str] = None, puuid: str=None, name: str = None, region: Union[Region, str], ) -> dict:
         query = {"region": region}
         if id is not None:
             query["id"] = id
@@ -231,9 +231,11 @@ class Summoner(CassiopeiaGhost):
         positions = self.league_positions
         ids = {position.league_id for position in positions}
         # HOTFIX:
+        from .league import LeagueListData
         queues = {position.league_id: position.queue for position in positions}
         leagues = SummonerLeagues([League(id=id_, region=self.region) for id_ in ids])
-        leagues.set_queues(queues)
+        for league in leagues:
+            league._data[LeagueListData].queue = queues[league.id]
         return SummonerLeagues([League(id=id_, region=self.region) for id_ in ids])
 
     @property

--- a/cassiopeia/core/summoner.py
+++ b/cassiopeia/core/summoner.py
@@ -86,7 +86,8 @@ class Summoner(CassiopeiaGhost):
             query["name"] = name
         if account and isinstance(account, Account):
             query["account.id"] = account.id
-            query["account.puuid"] = account.puui
+            if "puuid" in account:
+                query["account.puuid"] = account.puuid
         else:
             if account is not None:
                 query["account.id"] = account

--- a/cassiopeia/core/summoner.py
+++ b/cassiopeia/core/summoner.py
@@ -230,6 +230,10 @@ class Summoner(CassiopeiaGhost):
         from .league import League, SummonerLeagues
         positions = self.league_positions
         ids = {position.league_id for position in positions}
+        # HOTFIX:
+        queues = {position.league_id: position.queue for position in positions}
+        leagues = SummonerLeagues([League(id=id_, region=self.region) for id_ in ids])
+        leagues.set_queues(queues)
         return SummonerLeagues([League(id=id_, region=self.region) for id_ in ids])
 
     @property

--- a/cassiopeia/datastores/cache.py
+++ b/cassiopeia/datastores/cache.py
@@ -16,7 +16,7 @@ from ..core.staticdata.language import LanguagesData, Locales
 from ..core.staticdata.languagestrings import LanguageStringsData, LanguageStrings
 from ..core.staticdata.version import VersionListData, Versions
 from ..core.championmastery import ChampionMasteryData, ChampionMasteryListData, ChampionMastery, ChampionMasteries
-from ..core.league import LeaguePositionsData, LeagueListData, MasterLeagueListData, ChallengerLeagueListData, LeagueEntries, League, ChallengerLeague, MasterLeague
+from ..core.league import LeaguePositionsData, LeagueListData, MasterLeagueListData, GrandmasterLeagueListData, ChallengerLeagueListData, LeagueEntries, League, ChallengerLeague, GrandmasterLeague, MasterLeague
 from ..core.match import MatchData, TimelineData, Match, Timeline
 from ..core.summoner import SummonerData, Summoner
 from ..core.status import ShardStatusData, ShardStatus
@@ -49,6 +49,7 @@ default_expirations = {
     LeagueEntries: datetime.timedelta(hours=6),
     League: datetime.timedelta(hours=6),
     ChallengerLeague: datetime.timedelta(hours=6),
+    GrandmasterLeague: datetime.timedelta(hours=6),
     MasterLeague: datetime.timedelta(hours=6),
     Match: datetime.timedelta(days=3),
     Timeline: datetime.timedelta(days=1),
@@ -283,6 +284,27 @@ class Cache(DataSource, DataSink):
     @put_many.register(ChallengerLeague)
     def put_many_league_summoner(self, items: Iterable[ChallengerLeague], context: PipelineContext = None) -> None:
         self._put_many(ChallengerLeague, items, uniquekeys.for_challenger_league, context=context)
+
+    # Grandmaster
+
+    @get.register(GrandmasterLeague)
+    @validate_query(uniquekeys.validate_grandmaster_league_query, uniquekeys.convert_region_to_platform)
+    def get_league_summoner(self, query: Mapping[str, Any], context: PipelineContext = None) -> GrandmasterLeague:
+        return self._get(GrandmasterLeague, query, uniquekeys.for_grandmaster_league_query, context)
+
+    @get_many.register(GrandmasterLeague)
+    @validate_query(uniquekeys.validate_many_grandmaster_league_query, uniquekeys.convert_region_to_platform)
+    def get_many_league_summoner(self, query: Mapping[str, Any], context: PipelineContext = None) -> Generator[GrandmasterLeague, None, None]:
+        return self._get_many(GrandmasterLeague, query, uniquekeys.for_many_grandmaster_league_query, context)
+
+    @put.register(GrandmasterLeague)
+    def put_league_summoner(self, item: GrandmasterLeague, context: PipelineContext = None) -> None:
+        self._put(GrandmasterLeague, item, uniquekeys.for_grandmaster_league, context=context)
+
+    @put_many.register(GrandmasterLeague)
+    def put_many_league_summoner(self, items: Iterable[GrandmasterLeague], context: PipelineContext = None) -> None:
+        self._put_many(GrandmasterLeague, items, uniquekeys.for_grandmaster_league, context=context)
+
 
     # Master
 

--- a/cassiopeia/datastores/ghost.py
+++ b/cassiopeia/datastores/ghost.py
@@ -135,7 +135,7 @@ class UnloadedGhostStore(DataSource):
         has("summoner.id").as_(str)
 
     _validate_get_league_entries_query = Query. \
-        has("summoner.id").as_(int).also. \
+        has("summoner.id").as_(str).also. \
         has("platform").as_(Platform)
 
     _validate_get_league_query = Query. \

--- a/cassiopeia/datastores/ghost.py
+++ b/cassiopeia/datastores/ghost.py
@@ -127,12 +127,12 @@ class UnloadedGhostStore(DataSource):
 
     _validate_get_champion_mastery_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").also. \
+        has("summoner.id").as_(str).also. \
         has("champion.id").as_(int)
 
     _validate_get_champion_masteries_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").as_(int)
+        has("summoner.id").as_(str)
 
     _validate_get_league_entries_query = Query. \
         has("summoner.id").as_(int).also. \

--- a/cassiopeia/datastores/ghost.py
+++ b/cassiopeia/datastores/ghost.py
@@ -166,7 +166,7 @@ class UnloadedGhostStore(DataSource):
         has("platform").as_(Platform)
 
     _validate_get_match_history_query = Query. \
-        has("account.id").as_(str).also. \
+        has("accountId").as_(str).also. \
         has("platform").as_(Platform).also. \
         can_have("beginTime").as_(int).also. \
         can_have("endTime").as_(int).also. \
@@ -185,8 +185,8 @@ class UnloadedGhostStore(DataSource):
 
     _validate_get_summoner_query = Query. \
         has("id").as_(str). \
-        or_("account.id").as_(str). \
-        or_("account.puuid").as_(str). \
+        or_("accountId").as_(str). \
+        or_("puuid").as_(str). \
         or_("name").as_(str).also. \
         has("platform").as_(Platform)
 
@@ -249,10 +249,10 @@ class UnloadedGhostStore(DataSource):
     @validate_query(_validate_get_summoner_query, convert_region_to_platform)
     def get_summoner(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Summoner:
         query["region"] = query.pop("platform").region
-        if "account.id" in query:
-            query["account"] = query.pop("account.id")
-        if "account.puuid" in query:
-            query["puuid"] = query.pop("account.puuid")
+        if "accountId" in query:
+            query["accountId"] = query.pop("accountId")
+        if "puuid" in query:
+            query["puuid"] = query.pop("puuid")
         return Summoner._construct_normally(**query)
 
     @get.register(ChampionMastery)
@@ -263,8 +263,8 @@ class UnloadedGhostStore(DataSource):
             query["summoner"] = query.pop("summoner.id")
         if "summoner.name" in query:
             query["summoner"] = query.pop("summoner.name")
-        if "summoner.account.id" in query:
-            query["_account_id"] = query.pop("summoner.account.id")
+        if "summoner.accountId" in query:
+            query["_account_id"] = query.pop("summoner.accountId")
         if "champion.id" in query:
             query["champion"] = query.pop("champion.id")
         if "champion.id" in query:
@@ -335,7 +335,7 @@ class UnloadedGhostStore(DataSource):
     def get_match_history(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> MatchHistory:
         original_query = copy.deepcopy(query)
         region = query["region"]
-        account_id = query["account.id"]
+        account_id = query["accountId"]
         begin_index = query.get("beginIndex", 0)
         end_index = query.get("endIndex", None)
         first_requested_dt = query.get("beginTime", 0)  # (begin_time) Defaults to start of summoner's match history
@@ -364,7 +364,7 @@ class UnloadedGhostStore(DataSource):
             while pulled_matches < max_number_of_requested_matches:
                 new_query = {
                     "region": region,
-                    "account.id": account_id,
+                    "accountId": account_id,
                     "queues": queues,
                     "seasons": seasons,
                     "champion.ids": champion_ids,

--- a/cassiopeia/datastores/ghost.py
+++ b/cassiopeia/datastores/ghost.py
@@ -180,8 +180,9 @@ class UnloadedGhostStore(DataSource):
         has("platform").as_(Platform)
 
     _validate_get_summoner_query = Query. \
-        has("id").as_(int). \
-        or_("account.id").as_(int). \
+        has("id").as_(str). \
+        or_("account.id").as_(str). \
+        or_("account.puuid").as_(str). \
         or_("name").as_(str).also. \
         has("platform").as_(Platform)
 
@@ -246,6 +247,8 @@ class UnloadedGhostStore(DataSource):
         query["region"] = query.pop("platform").region
         if "account.id" in query:
             query["account"] = query.pop("account.id")
+        if "account.puuid" in query:
+            query["puuid"] = query.pop("account.puuid")
         return Summoner._construct_normally(**query)
 
     @get.register(ChampionMastery)

--- a/cassiopeia/datastores/ghost.py
+++ b/cassiopeia/datastores/ghost.py
@@ -162,7 +162,7 @@ class UnloadedGhostStore(DataSource):
         has("platform").as_(Platform)
 
     _validate_get_match_history_query = Query. \
-        has("account.id").as_(int).also. \
+        has("account.id").as_(str).also. \
         has("platform").as_(Platform).also. \
         can_have("beginTime").as_(int).also. \
         can_have("endTime").as_(int).also. \

--- a/cassiopeia/datastores/ghost.py
+++ b/cassiopeia/datastores/ghost.py
@@ -5,7 +5,7 @@ import copy
 from datapipelines import DataSource, PipelineContext, Query, validate_query
 
 from ..data import Platform, Queue
-from ..core import Champion, Rune, Item, Map, SummonerSpell, Realms, ProfileIcon, LanguageStrings, Summoner, ChampionMastery, Match, CurrentMatch, ShardStatus, ChallengerLeague, MasterLeague, League, MatchHistory, Items, Champions, Maps, ProfileIcons, Locales, Runes, SummonerSpells, Versions, ChampionMasteries, LeagueEntries, FeaturedMatches, VerificationString, Account
+from ..core import Champion, Rune, Item, Map, SummonerSpell, Realms, ProfileIcon, LanguageStrings, Summoner, ChampionMastery, Match, CurrentMatch, ShardStatus, ChallengerLeague, GrandmasterLeague, MasterLeague, League, MatchHistory, Items, Champions, Maps, ProfileIcons, Locales, Runes, SummonerSpells, Versions, ChampionMasteries, LeagueEntries, FeaturedMatches, VerificationString, Account
 from ..core.match import Timeline, MatchListData
 from ..core.championmastery import ChampionMasteryListData
 from ..core.league import LeaguePositionsData, LeagueEntry
@@ -143,6 +143,10 @@ class UnloadedGhostStore(DataSource):
         has("platform").as_(Platform)
 
     _validate_get_challenger_league_query = Query. \
+        has("queue").as_(Queue).also. \
+        has("platform").as_(Platform)
+
+    _validate_get_grandmaster_league_query = Query. \
         has("queue").as_(Queue).also. \
         has("platform").as_(Platform)
 
@@ -298,6 +302,13 @@ class UnloadedGhostStore(DataSource):
         UnloadedGhostStore._validate_get_challenger_league_query(query)
         query["region"] = query.pop("platform").region
         return ChallengerLeague._construct_normally(**query)
+
+    @get.register(GrandmasterLeague)
+    @validate_query(_validate_get_grandmaster_league_query, convert_region_to_platform)
+    def get_grandmaster_league(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> GrandmasterLeague:
+        UnloadedGhostStore._validate_get_grandmaster_league_query(query)
+        query["region"] = query.pop("platform").region
+        return GrandmasterLeague._construct_normally(**query)
 
     @get.register(MasterLeague)
     @validate_query(_validate_get_master_league_query, convert_region_to_platform)

--- a/cassiopeia/datastores/ghost.py
+++ b/cassiopeia/datastores/ghost.py
@@ -188,7 +188,7 @@ class UnloadedGhostStore(DataSource):
 
     _validate_get_verification_string_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").as_(int)
+        has("summoner.id").as_(str)
 
     @get.register(Champion)
     @validate_query(_validate_get_champion_query, convert_region_to_platform)

--- a/cassiopeia/datastores/ghost.py
+++ b/cassiopeia/datastores/ghost.py
@@ -152,7 +152,7 @@ class UnloadedGhostStore(DataSource):
 
     _validate_get_current_match_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").as_(int)
+        has("summoner.id").as_(str)
 
     _validate_get_featured_matches_query = Query. \
         has("platform").as_(Platform)

--- a/cassiopeia/datastores/riotapi/championmastery.py
+++ b/cassiopeia/datastores/riotapi/championmastery.py
@@ -20,13 +20,13 @@ class ChampionMasteryAPI(RiotAPIService):
 
     _validate_get_champion_mastery_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").also. \
+        has("summoner.id").as_(str).also. \
         has("champion.id").as_(int)
 
     @get.register(ChampionMasteryDto)
     @validate_query(_validate_get_champion_mastery_query, convert_region_to_platform)
     def get_champion_mastery(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> ChampionMasteryDto:
-        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v3/champion-masteries/by-summoner/{summonerId}/by-champion/{championId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"], championId=query["champion.id"])
+        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-summoner/{summonerId}/by-champion/{championId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"], championId=query["champion.id"])
         try:
             endpoint = "champion-masteries/by-summoner/summonerId/by-champion/championId"
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -40,13 +40,13 @@ class ChampionMasteryAPI(RiotAPIService):
 
     _validate_get_many_champion_mastery_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summonerId").as_(int).also. \
+        has("summonerId").as_(str).also. \
         has("championIds").as_(Iterable)
 
     @get_many.register(ChampionMasteryDto)
     @validate_query(_validate_get_many_champion_mastery_query, convert_region_to_platform)
     def get_many_champion_mastery(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Generator[ChampionMasteryDto, None, None]:
-        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v3/champion-masteries/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summonerId"])
+        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summonerId"])
         try:
             endpoint = "champion-masteries/by-summoner/summonerId"
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -73,12 +73,12 @@ class ChampionMasteryAPI(RiotAPIService):
 
     _validate_get_champion_mastery_list_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").as_(int)
+        has("summoner.id").as_(str)
 
     @get.register(ChampionMasteryListDto)
     @validate_query(_validate_get_champion_mastery_list_query, convert_region_to_platform)
     def get_champion_mastery_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> ChampionMasteryListDto:
-        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v3/champion-masteries/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"])
+        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"])
         try:
             endpoint = "champion-masteries/by-summoner/summonerId"
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -103,7 +103,7 @@ class ChampionMasteryAPI(RiotAPIService):
     def get_many_champion_mastery_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Generator[ChampionMasteryListDto, None, None]:
         def generator():
             for summoner_id in query["summoner.ids"]:
-                url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v3/champion-masteries/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=summoner_id)
+                url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=summoner_id)
                 try:
                     endpoint = "champion-masteries/by-summoner/summonerId"
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -121,12 +121,12 @@ class ChampionMasteryAPI(RiotAPIService):
 
     _validate_get_champion_mastery_score_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").as_(int)
+        has("summoner.id").as_(str)
 
     @get.register(ChampionMasteryScoreDto)
     @validate_query(_validate_get_champion_mastery_score_query, convert_region_to_platform)
     def get_champion_mastery_score(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> ChampionMasteryScoreDto:
-        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v3/scores/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"])
+        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/scores/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"])
         try:
             endpoint = "scores/by-summoner/summonerId"
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -149,7 +149,7 @@ class ChampionMasteryAPI(RiotAPIService):
     def get_many_champion_mastery_score(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Generator[ChampionMasteryScoreDto, None, None]:
         def generator():
             for summoner_id in query["summoner.ids"]:
-                url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v3/scores/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=summoner_id)
+                url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/scores/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=summoner_id)
                 try:
                     endpoint = "scores/by-summoner/summonerId"
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)

--- a/cassiopeia/datastores/riotapi/leagues.py
+++ b/cassiopeia/datastores/riotapi/leagues.py
@@ -21,13 +21,13 @@ class LeaguesAPI(RiotAPIService):
     # League positions
 
     _validate_get_league_positions_query = Query. \
-        has("summoner.id").as_(int).also. \
+        has("summoner.id").as_(str).also. \
         has("platform").as_(Platform)
 
     @get.register(LeaguePositionsDto)
     @validate_query(_validate_get_league_positions_query, convert_region_to_platform)
     def get_league_position(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> LeaguePositionsDto:
-        url = "https://{platform}.api.riotgames.com/lol/league/v3/positions/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"])
+        url = "https://{platform}.api.riotgames.com/lol/league/v4/positions/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"])
         try:
             endpoint = "positions/by-summoner/summonerId {}".format(query["platform"].value)
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -77,7 +77,7 @@ class LeaguesAPI(RiotAPIService):
     @get.register(LeagueListDto)
     @validate_query(_validate_get_leagues_query, convert_region_to_platform)
     def get_leagues_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> LeagueListDto:
-        url = "https://{platform}.api.riotgames.com/lol/league/v3/leagues/{leagueId}".format(platform=query["platform"].value.lower(), leagueId=query["id"])
+        url = "https://{platform}.api.riotgames.com/lol/league/v4/leagues/{leagueId}".format(platform=query["platform"].value.lower(), leagueId=query["id"])
         try:
             endpoint = "leagues/leagueId {}".format(query["platform"].value)
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -100,7 +100,7 @@ class LeaguesAPI(RiotAPIService):
     def get_many_leagues_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Generator[LeaguesListDto, None, None]:
         def generator():
             for id in query["summoner.ids"]:
-                url = "https://{platform}.api.riotgames.com/lol/league/v3/leagues/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=id)
+                url = "https://{platform}.api.riotgames.com/lol/league/v4/leagues/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=id)
                 try:
                     endpoint = "leagues/by-summoner/summonerId {}".format(query["platform"].value)
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -125,7 +125,7 @@ class LeaguesAPI(RiotAPIService):
     def get_many_leagues_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Generator[LeagueListDto, None, None]:
         def generator():
             for id in query["ids"]:
-                url = "https://{platform}.api.riotgames.com/lol/league/v3/leagues/{leagueId}".format(platform=query["platform"].value.lower(), leagueId=id)
+                url = "https://{platform}.api.riotgames.com/lol/league/v4/leagues/{leagueId}".format(platform=query["platform"].value.lower(), leagueId=id)
                 try:
                     endpoint = "leagues/leagueId {}".format(query["platform"].value)
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -151,7 +151,7 @@ class LeaguesAPI(RiotAPIService):
     @get.register(ChallengerLeagueListDto)
     @validate_query(_validate_get_challenger_league_query, convert_region_to_platform)
     def get_challenger_league_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> ChallengerLeagueListDto:
-        url = "https://{platform}.api.riotgames.com/lol/league/v3/challengerleagues/by-queue/{queueName}".format(platform=query["platform"].value.lower(), queueName=query["queue"].value)
+        url = "https://{platform}.api.riotgames.com/lol/league/v4/challengerleagues/by-queue/{queueName}".format(platform=query["platform"].value.lower(), queueName=query["queue"].value)
         try:
             endpoint = "challengerleagues/by-queue {}".format(query["platform"].value)
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -174,7 +174,7 @@ class LeaguesAPI(RiotAPIService):
     def get_challenger_leagues_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Generator[ChallengerLeagueListDto, None, None]:
         def generator():
             for queue in query["queues"]:
-                url = "https://{platform}.api.riotgames.com/lol/league/v3/challengerleagues/by-queue/{queueName}".format(platform=query["platform"].value.lower(), queueName=queue.value)
+                url = "https://{platform}.api.riotgames.com/lol/league/v4/challengerleagues/by-queue/{queueName}".format(platform=query["platform"].value.lower(), queueName=queue.value)
                 try:
                     endpoint = "challengerleagues/by-queue {}".format(query["platform"].value)
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -199,7 +199,7 @@ class LeaguesAPI(RiotAPIService):
     @get.register(MasterLeagueListDto)
     @validate_query(_validate_get_master_league_query, convert_region_to_platform)
     def get_master_league_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> MasterLeagueListDto:
-        url = "https://{platform}.api.riotgames.com/lol/league/v3/masterleagues/by-queue/{queueName}".format(platform=query["platform"].value.lower(), queueName=query["queue"].value)
+        url = "https://{platform}.api.riotgames.com/lol/league/v4/masterleagues/by-queue/{queueName}".format(platform=query["platform"].value.lower(), queueName=query["queue"].value)
         try:
             endpoint = "masterleagues/by-queue {}".format(query["platform"].value)
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)
@@ -222,7 +222,7 @@ class LeaguesAPI(RiotAPIService):
     def get_master_leagues_list(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Generator[MasterLeagueListDto, None, None]:
         def generator():
             for queue in query["queues"]:
-                url = "https://{platform}.api.riotgames.com/lol/league/v3/masterleagues/by-queue/{queueName}".format(platform=query["platform"].value.lower(), queueName=queue.value)
+                url = "https://{platform}.api.riotgames.com/lol/league/v4/masterleagues/by-queue/{queueName}".format(platform=query["platform"].value.lower(), queueName=queue.value)
                 try:
                     endpoint = "masterleagues/by-queue {}".format(query["platform"].value)
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], endpoint)

--- a/cassiopeia/datastores/riotapi/match.py
+++ b/cassiopeia/datastores/riotapi/match.py
@@ -34,7 +34,7 @@ class MatchAPI(RiotAPIService):
     @get.register(MatchDto)
     @validate_query(_validate_get_match_query, convert_region_to_platform)
     def get_match(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> MatchDto:
-        url = "https://{platform}.api.riotgames.com/lol/match/v3/matches/{id}".format(platform=query["platform"].value.lower(), id=query["id"])
+        url = "https://{platform}.api.riotgames.com/lol/match/v4/matches/{id}".format(platform=query["platform"].value.lower(), id=query["id"])
         try:
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "matches/id")
             data = self._get(url, {}, app_limiter=app_limiter, method_limiter=method_limiter)
@@ -58,7 +58,7 @@ class MatchAPI(RiotAPIService):
     def get_many_match(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Generator[MatchDto, None, None]:
         def generator():
             for id in query["ids"]:
-                url = "https://{platform}.api.riotgames.com/lol/match/v3/matches/{id}".format(platform=query["platform"].value.lower(), id=id)
+                url = "https://{platform}.api.riotgames.com/lol/match/v4/matches/{id}".format(platform=query["platform"].value.lower(), id=id)
                 try:
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "matches/id")
                     data = self._get(url, {}, app_limiter=app_limiter, method_limiter=method_limiter)
@@ -79,7 +79,7 @@ class MatchAPI(RiotAPIService):
         return generator()
 
     _validate_get_match_list_query = Query. \
-        has("account.id").as_(int).also. \
+        has("account.id").as_(str).also. \
         has("platform").as_(Platform).also. \
         has("beginTime").as_(int).also. \
         can_have("endTime").as_(int).also. \
@@ -148,7 +148,7 @@ class MatchAPI(RiotAPIService):
         else:
             queues = set()
 
-        url = "https://{platform}.api.riotgames.com/lol/match/v3/matchlists/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=query["account.id"])
+        url = "https://{platform}.api.riotgames.com/lol/match/v4/matchlists/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=query["account.id"])
         try:
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "matchlists/by-account/accountId")
             data = self._get(url, params, app_limiter=app_limiter, method_limiter=method_limiter)
@@ -211,7 +211,7 @@ class MatchAPI(RiotAPIService):
 
         def generator():
             for id in query["account.ids"]:
-                url = "https://{platform}.api.riotgames.com/lol/match/v3/matchlists/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=id)
+                url = "https://{platform}.api.riotgames.com/lol/match/v4/matchlists/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=id)
                 try:
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "matchlists/by-account/accountId")
                     data = self._get(url, params, app_limiter=app_limiter, method_limiter=method_limiter)
@@ -241,7 +241,7 @@ class MatchAPI(RiotAPIService):
     @get.register(TimelineDto)
     @validate_query(_validate_get_timeline_query, convert_region_to_platform)
     def get_match_timeline(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> TimelineDto:
-        url = "https://{platform}.api.riotgames.com/lol/match/v3/timelines/by-match/{id}".format(platform=query["platform"].value.lower(), id=query["id"])
+        url = "https://{platform}.api.riotgames.com/lol/match/v4/timelines/by-match/{id}".format(platform=query["platform"].value.lower(), id=query["id"])
         try:
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "timelines/by-match/id")
             data = self._get(url, {}, app_limiter=app_limiter, method_limiter=method_limiter)
@@ -261,7 +261,7 @@ class MatchAPI(RiotAPIService):
     def get_many_match_timeline(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> Generator[TimelineDto, None, None]:
         def generator():
             for id in query["ids"]:
-                url = "https://{platform}.api.riotgames.com/lol/match/v3/timelines/by-match/{id}".format(platform=query["platform"].value.lower(), id=id)
+                url = "https://{platform}.api.riotgames.com/lol/match/v4/timelines/by-match/{id}".format(platform=query["platform"].value.lower(), id=id)
                 try:
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "timelines/by-match/id")
                     data = self._get(url, {}, app_limiter=app_limiter, method_limiter=method_limiter)

--- a/cassiopeia/datastores/riotapi/match.py
+++ b/cassiopeia/datastores/riotapi/match.py
@@ -79,7 +79,7 @@ class MatchAPI(RiotAPIService):
         return generator()
 
     _validate_get_match_list_query = Query. \
-        has("account.id").as_(str).also. \
+        has("accountId").as_(str).also. \
         has("platform").as_(Platform).also. \
         has("beginTime").as_(int).also. \
         can_have("endTime").as_(int).also. \
@@ -148,14 +148,14 @@ class MatchAPI(RiotAPIService):
         else:
             queues = set()
 
-        url = "https://{platform}.api.riotgames.com/lol/match/v4/matchlists/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=query["account.id"])
+        url = "https://{platform}.api.riotgames.com/lol/match/v4/matchlists/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=query["accountId"])
         try:
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "matchlists/by-account/accountId")
             data = self._get(url, params, app_limiter=app_limiter, method_limiter=method_limiter)
         except APINotFoundError:
             data = {"matches": []}
 
-        data["accountId"] = query["account.id"]
+        data["accountId"] = query["accountId"]
         data["region"] = query["platform"].region.value
         data["season"] = seasons
         data["champion"] = champions
@@ -168,12 +168,12 @@ class MatchAPI(RiotAPIService):
             data["beginTime"] = params["beginTime"]
             data["endTime"] = params["endTime"]
         for match in data["matches"]:
-            match["accountId"] = query["account.id"]
+            match["accountId"] = query["accountId"]
             match["region"] = Platform(match["platformId"]).region.value
         return MatchListDto(data)
 
     _validate_get_many_match_list_query = Query. \
-        has("account.ids").as_(Iterable).also. \
+        has("accountIds").as_(Iterable).also. \
         has("platform").as_(Platform).also. \
         can_have("beginTime").as_(int).also. \
         can_have("endTime").as_(int).also. \
@@ -210,7 +210,7 @@ class MatchAPI(RiotAPIService):
             queues = set()
 
         def generator():
-            for id in query["account.ids"]:
+            for id in query["accountIds"]:
                 url = "https://{platform}.api.riotgames.com/lol/match/v4/matchlists/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=id)
                 try:
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "matchlists/by-account/accountId")
@@ -218,7 +218,7 @@ class MatchAPI(RiotAPIService):
                 except APINotFoundError as error:
                     raise NotFoundError(str(error)) from error
 
-                data["account.id"] = id
+                data["accountId"] = id
                 data["region"] = query["platform"].region.value
                 if "beginIndex" in query:
                     data["beginIndex"] = query["beginIndex"]

--- a/cassiopeia/datastores/riotapi/spectator.py
+++ b/cassiopeia/datastores/riotapi/spectator.py
@@ -35,12 +35,12 @@ class SpectatorAPI(RiotAPIService):
 
     _validate_get_current_game_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").as_(int)
+        has("summoner.id").as_(str)
 
     @get.register(CurrentGameInfoDto)
     @validate_query(_validate_get_current_game_query, convert_region_to_platform)
     def get_current_game(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> CurrentGameInfoDto:
-        url = "https://{platform}.api.riotgames.com/lol/spectator/v3/active-games/by-summoner/{id}".format(platform=query["platform"].value.lower(), id=query["summoner.id"])
+        url = "https://{platform}.api.riotgames.com/lol/spectator/v4/active-games/by-summoner/{id}".format(platform=query["platform"].value.lower(), id=query["summoner.id"])
         try:
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"],"spectator/active-games/by-summoner")
             data = self._get(url, {}, app_limiter=app_limiter, method_limiter=method_limiter)
@@ -61,7 +61,7 @@ class SpectatorAPI(RiotAPIService):
     @get.register(FeaturedGamesDto)
     @validate_query(_validate_get_featured_game_query, convert_region_to_platform)
     def get_featured_games(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> FeaturedGamesDto:
-        url = "https://{platform}.api.riotgames.com/lol/spectator/v3/featured-games".format(platform=query["platform"].value.lower())
+        url = "https://{platform}.api.riotgames.com/lol/spectator/v4/featured-games".format(platform=query["platform"].value.lower())
         try:
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "featured-games")
             data = self._get(url, {}, app_limiter=app_limiter, method_limiter=method_limiter)

--- a/cassiopeia/datastores/riotapi/summoner.py
+++ b/cassiopeia/datastores/riotapi/summoner.py
@@ -19,8 +19,9 @@ class SummonerAPI(RiotAPIService):
         pass
 
     _validate_get_summoner_query = Query. \
-        has("id").as_(int). \
-        or_("account.id").as_(int). \
+        has("id").as_(str). \
+        or_("account.id").as_(str). \
+        or_("account.puuid").as_(str). \
         or_("name").as_(str).also. \
         has("platform").as_(Platform)
 
@@ -28,14 +29,17 @@ class SummonerAPI(RiotAPIService):
     @validate_query(_validate_get_summoner_query, convert_region_to_platform)
     def get_summoner(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> SummonerDto:
         if "id" in query:
-            url = "https://{platform}.api.riotgames.com/lol/summoner/v3/summoners/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["id"])
+            url = "https://{platform}.api.riotgames.com/lol/summoner/v4/summoners/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["id"])
             endpoint = "summoners/summonerId"
         elif "account.id" in query:
-            url = "https://{platform}.api.riotgames.com/lol/summoner/v3/summoners/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=query["account.id"])
+            url = "https://{platform}.api.riotgames.com/lol/summoner/v4/summoners/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=query["account.id"])
             endpoint = "summoners/by-account/accountId"
         elif "name" in query:
-            url = "https://{platform}.api.riotgames.com/lol/summoner/v3/summoners/by-name/{name}".format(platform=query["platform"].value.lower(), name=query["name"].replace(" ", "")).encode("utf-8")
+            url = "https://{platform}.api.riotgames.com/lol/summoner/v4/summoners/by-name/{name}".format(platform=query["platform"].value.lower(), name=query["name"].replace(" ", "")).encode("utf-8")
             endpoint = "summoners/by-name/name"
+        elif "account.puuid" in query:
+            url = url = "https://{platform}.api.riotgames.com/lol/summoner/v4/summoners/by-puuid/{puuid}".format(platform=query["platform"].value.lower(), puuid=query["account.puuid"])
+            endpoint = "summoners/by-puuid/puuid"
         else:
             endpoint = ""
 

--- a/cassiopeia/datastores/riotapi/summoner.py
+++ b/cassiopeia/datastores/riotapi/summoner.py
@@ -20,8 +20,8 @@ class SummonerAPI(RiotAPIService):
 
     _validate_get_summoner_query = Query. \
         has("id").as_(str). \
-        or_("account.id").as_(str). \
-        or_("account.puuid").as_(str). \
+        or_("accountId").as_(str). \
+        or_("puuid").as_(str). \
         or_("name").as_(str).also. \
         has("platform").as_(Platform)
 
@@ -31,8 +31,8 @@ class SummonerAPI(RiotAPIService):
         if "id" in query:
             url = "https://{platform}.api.riotgames.com/lol/summoner/v4/summoners/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["id"])
             endpoint = "summoners/summonerId"
-        elif "account.id" in query:
-            url = "https://{platform}.api.riotgames.com/lol/summoner/v4/summoners/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=query["account.id"])
+        elif "accountId" in query:
+            url = "https://{platform}.api.riotgames.com/lol/summoner/v4/summoners/by-account/{accountId}".format(platform=query["platform"].value.lower(), accountId=query["accountId"])
             endpoint = "summoners/by-account/accountId"
         elif "name" in query:
             url = "https://{platform}.api.riotgames.com/lol/summoner/v4/summoners/by-name/{name}".format(platform=query["platform"].value.lower(), name=query["name"].replace(" ", "")).encode("utf-8")

--- a/cassiopeia/datastores/riotapi/thirdpartycode.py
+++ b/cassiopeia/datastores/riotapi/thirdpartycode.py
@@ -28,12 +28,12 @@ class ThirdPartyCodeAPI(RiotAPIService):
 
     _validate_get_verification_string_query = Query. \
         has("platform").as_(Platform).also. \
-        has("summoner.id").as_(int)
+        has("summoner.id").as_(str)
 
     @get.register(VerificationStringDto)
     @validate_query(_validate_get_verification_string_query, convert_region_to_platform)
     def get_verification_string(self, query: MutableMapping[str, Any], context: PipelineContext = None) -> VerificationStringDto:
-        url = "https://{platform}.api.riotgames.com/lol/platform/v3/third-party-code/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"])
+        url = "https://{platform}.api.riotgames.com/lol/platform/v4/third-party-code/by-summoner/{summonerId}".format(platform=query["platform"].value.lower(), summonerId=query["summoner.id"])
         try:
             app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "thirdpartycode")
             data = self._get(url, {}, app_limiter=app_limiter, method_limiter=method_limiter)
@@ -55,7 +55,7 @@ class ThirdPartyCodeAPI(RiotAPIService):
         def generator():
             for platform, summoner_id in zip(query["platforms"], query["summoner.ids"]):
                 platform = Platform(platform.upper())
-                url = "https://{platform}.api.riotgames.com/lol/platform/v3/third-party-code/by-summoner/{summonerId}".format(platform=platform.value.lower(), summonerId=summoner_id)
+                url = "https://{platform}.api.riotgames.com/lol/platform/v4/third-party-code/by-summoner/{summonerId}".format(platform=platform.value.lower(), summonerId=summoner_id)
                 try:
                     app_limiter, method_limiter = self._get_rate_limiter(query["platform"], "thirdpartycode")
                     data = self._get(url, {}, app_limiter=app_limiter, method_limiter=method_limiter)

--- a/cassiopeia/datastores/uniquekeys.py
+++ b/cassiopeia/datastores/uniquekeys.py
@@ -121,25 +121,25 @@ def for_many_champion_rotation_dto_query(query: Query) -> Generator[str, None, N
 
 validate_champion_mastery_dto_query = Query. \
     has("platform").as_(Platform).also. \
-    has("playerId").as_(int).also. \
+    has("playerId").as_(str).also. \
     has("championId").as_(int)
 
 
 validate_many_champion_mastery_dto_query = Query. \
     has("platform").as_(Platform).also. \
-    has("playerId").as_(int).also. \
+    has("playerId").as_(str).also. \
     has("championIds").as_(Iterable)
 
 
-def for_champion_mastery_dto(champion_mastery: ChampionMasteryDto) -> Tuple[str, int, int]:
+def for_champion_mastery_dto(champion_mastery: ChampionMasteryDto) -> Tuple[str, str, int]:
     return champion_mastery["platform"], champion_mastery["playerId"], champion_mastery["championId"]
 
 
-def for_champion_mastery_dto_query(query: Query) -> Tuple[str, int, int]:
+def for_champion_mastery_dto_query(query: Query) -> Tuple[str, str, int]:
     return query["platform"].value, query["playerId"], query["championId"]
 
 
-def for_many_champion_mastery_dto_query(query: Query) -> Generator[Tuple[str, int, int], None, None]:
+def for_many_champion_mastery_dto_query(query: Query) -> Generator[Tuple[str, str, int], None, None]:
     for champion_id in query["championIds"]:
         try:
             champion_id = int(champion_id)
@@ -150,7 +150,7 @@ def for_many_champion_mastery_dto_query(query: Query) -> Generator[Tuple[str, in
 
 validate_champion_mastery_list_dto_query = Query. \
     has("platform").as_(Platform).also. \
-    has("playerId").as_(int)
+    has("playerId").as_(str)
 
 
 validate_many_champion_mastery_list_dto_query = Query. \
@@ -158,18 +158,17 @@ validate_many_champion_mastery_list_dto_query = Query. \
     has("playerIds").as_(Iterable)
 
 
-def for_champion_mastery_list_dto(champion_mastery_list: ChampionMasteryListDto) -> Tuple[str, int]:
+def for_champion_mastery_list_dto(champion_mastery_list: ChampionMasteryListDto) -> Tuple[str, str]:
     return champion_mastery_list["platform"], champion_mastery_list["playerId"]
 
 
-def for_champion_mastery_list_dto_query(query: Query) -> Tuple[str, int]:
+def for_champion_mastery_list_dto_query(query: Query) -> Tuple[str, str]:
     return query["platform"].value, query["playerId"]
 
 
-def for_many_champion_mastery_list_dto_query(query: Query) -> Generator[Tuple[str, int], None, None]:
+def for_many_champion_mastery_list_dto_query(query: Query) -> Generator[Tuple[str, str], None, None]:
     for summoner_id in query["playerIds"]:
         try:
-            summoner_id = int(summoner_id)
             yield query["platform"].value, summoner_id
         except ValueError as e:
             raise QueryValidationError from e
@@ -177,7 +176,7 @@ def for_many_champion_mastery_list_dto_query(query: Query) -> Generator[Tuple[st
 
 validate_champion_mastery_score_dto_query = Query. \
     has("platform").as_(Platform).also. \
-    has("playerId").as_(int)
+    has("playerId").as_(str)
 
 
 validate_many_champion_mastery_score_dto_query = Query. \
@@ -185,18 +184,17 @@ validate_many_champion_mastery_score_dto_query = Query. \
     has("playerIds").as_(Iterable)
 
 
-def for_champion_mastery_score_dto(champion_mastery_score: ChampionMasteryScoreDto) -> Tuple[str, int]:
+def for_champion_mastery_score_dto(champion_mastery_score: ChampionMasteryScoreDto) -> Tuple[str, str]:
     return champion_mastery_score["platform"], champion_mastery_score["playerId"]
 
 
-def for_champion_mastery_score_dto_query(query: Query) -> Tuple[str, int]:
+def for_champion_mastery_score_dto_query(query: Query) -> Tuple[str, str]:
     return query["platform"].value, query["playerId"]
 
 
-def for_many_champion_mastery_score_dto_query(query: Query) -> Generator[Tuple[str, int], None, None]:
+def for_many_champion_mastery_score_dto_query(query: Query) -> Generator[Tuple[str, str], None, None]:
     for summoner_id in query["playerIds"]:
         try:
-            summoner_id = int(summoner_id)
             yield query["platform"].value, summoner_id
         except ValueError as e:
             raise QueryValidationError from e
@@ -1040,13 +1038,13 @@ def for_champion_rotation_query(query: Query) -> List[str]:
 
 validate_champion_mastery_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(int).or_("summoner.account.id").as_(int).or_("summoner.name").as_(str).also. \
+    has("summoner.id").as_(str).or_("summoner.account.id").as_(str).or_("summoner.name").as_(str).also. \
     has("champion.id").as_(int).or_("champion.name").as_(str)
 
 
 validate_many_champion_mastery_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(int).or_("summoner.account.id").as_(int).or_("summoner.name").as_(str).also. \
+    has("summoner.id").as_(str).or_("summoner.account.id").as_(str).or_("summoner.name").as_(str).also. \
     has("champions.id").as_(Iterable).or_("champions.name").as_(Iterable)
 
 
@@ -1122,12 +1120,12 @@ def for_many_champion_mastery_query(query: Query) -> Generator[Tuple[str, str, s
 
 validate_champion_masteries_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(int).or_("summoner.account.id").as_(int).or_("summoner.name")
+    has("summoner.id").as_(str).or_("summoner.account.id").as_(int).or_("summoner.name")
 
 
 validate_many_champion_masteries_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(int).or_("summoner.account.id").as_(int).or_("summoner.name")
+    has("summoner.id").as_(str).or_("summoner.account.id").as_(int).or_("summoner.name")
 
 
 def for_champion_masteries(champion_mastery: ChampionMasteries) -> List[Tuple]:

--- a/cassiopeia/datastores/uniquekeys.py
+++ b/cassiopeia/datastores/uniquekeys.py
@@ -2045,12 +2045,12 @@ def for_many_featured_matches_query(query: Query) -> Generator[List[str], None, 
 
 validate_summoner_query = Query. \
     has("platform").as_(Platform).also. \
-    has("id").as_(int).or_("account.id").as_(int).or_("name").as_(str)
+    has("id").as_(str).or_("account.id").as_(str).or_("name").as_(str).or_("account.puuid").as_(str)
 
 
 validate_many_summoner_query = Query. \
     has("platform").as_(Platform).also. \
-    has("ids").as_(Iterable).or_("accounts.id").as_(Iterable).or_("names").as_(Iterable)
+    has("ids").as_(Iterable).or_("accounts.id").as_(Iterable).or_("names").as_(Iterable).or_("accounts.puuid").as_(Iterable)
 
 
 def for_summoner(summoner: Summoner) -> List[Tuple]:
@@ -2067,6 +2067,10 @@ def for_summoner(summoner: Summoner) -> List[Tuple]:
         keys.append((summoner.platform.value, "account", summoner._data[SummonerData].account.id))
     except AttributeError:
         pass
+    try:
+        keys.append((summoner.platform.value, "account", summoner._data[SummonerData].account.puuid))
+    except AttributeError:
+        pass
     return keys
 
 
@@ -2078,6 +2082,8 @@ def for_summoner_query(query: Query) -> List[Tuple]:
         keys.append((query["platform"].value, query["name"]))
     if "account.id" in query:
         keys.append((query["platform"].value, "account", query["account.id"]))
+    if "account.puuid" in query:
+        keys.append((query["platform"].value, "account", query["account.puuid"]))
     return keys
 
 
@@ -2086,10 +2092,13 @@ def for_many_summoner_query(query: Query) -> Generator[List[Tuple], None, None]:
     identifier_types = []
     if "ids" in query:
         grouped_identifiers.append(query["ids"])
-        identifier_types.append(int)
+        identifier_types.append(str)
     elif "accounts.id" in query:
         grouped_identifiers.append(query["accounts.id"])
-        identifier_types.append(int)
+        identifier_types.append(str)
+    elif "accounts.puuid" in query:
+        grouped_identifiers.append(query["accounts.puuid"])
+        identifier_types.append(str)
     elif "names" in query:
         grouped_identifiers.append(query["names"])
         identifier_types.append(str)

--- a/cassiopeia/datastores/uniquekeys.py
+++ b/cassiopeia/datastores/uniquekeys.py
@@ -1165,7 +1165,7 @@ def for_champion_masteries_query(query: Query) -> List[Tuple]:
 
 validate_league_entries_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(int)
+    has("summoner.id").as_(str)
 
 
 validate_many_league_entries_query = Query. \
@@ -1173,15 +1173,15 @@ validate_many_league_entries_query = Query. \
     has("summoners.id").as_(Iterable)
 
 
-def for_league_entries(entries: LeagueEntries) -> List[Tuple[str, int]]:
+def for_league_entries(entries: LeagueEntries) -> List[Tuple[str, str]]:
     return [(entries.platform.value, entries._LeagueEntries__summoner.id)]
 
 
-def for_league_entries_query(query: Query) -> List[Tuple[str, int]]:
+def for_league_entries_query(query: Query) -> List[Tuple[str, str]]:
     return [(query["platform"].value, query["summoner.id"])]
 
 
-def for_many_league_entries_query(query: Query) -> Generator[List[Tuple[str, int]], None, None]:
+def for_many_league_entries_query(query: Query) -> Generator[List[Tuple[str, str]], None, None]:
     for id in query["summoners.id"]:
         try:
             yield [(query["platform"].value, id)]
@@ -1200,15 +1200,15 @@ validate_many_league_query = Query. \
     has("ids").as_(Iterable)
 
 
-def for_league(league: League) -> List[Tuple[str, int]]:
+def for_league(league: League) -> List[Tuple[str, str]]:
     return [(league.platform.value, league.id)]
 
 
-def for_league_query(query: Query) -> List[Tuple[str, int]]:
+def for_league_query(query: Query) -> List[Tuple[str, str]]:
     return [(query["platform"].value, query["id"])]
 
 
-def for_many_league_query(query: Query) -> Generator[List[Tuple[str, int]], None, None]:
+def for_many_league_query(query: Query) -> Generator[List[Tuple[str, str]], None, None]:
     for id in query["ids"]:
         try:
             yield [(query["platform"].value, id)]

--- a/cassiopeia/datastores/uniquekeys.py
+++ b/cassiopeia/datastores/uniquekeys.py
@@ -14,7 +14,7 @@ from ..dto.spectator import CurrentGameInfoDto, FeaturedGamesDto
 from ..dto.summoner import SummonerDto
 
 from ..core.championmastery import ChampionMastery, ChampionMasteries
-from ..core.league import LeagueEntries, ChallengerLeague, MasterLeague, League
+from ..core.league import LeagueEntries, ChallengerLeague, GrandmasterLeague, MasterLeague, League
 from ..core.staticdata import Champion, Rune, Item, SummonerSpell, Map, Locales, LanguageStrings, ProfileIcon, ProfileIcons, Realms, Versions, Items, Champions, Maps, SummonerSpells, Runes
 from ..core.status import ShardStatus
 from ..core.match import Match, MatchHistory, Timeline
@@ -1236,6 +1236,33 @@ def for_challenger_league_query(query: Query) -> List[Tuple[str, str]]:
 
 
 def for_many_challenger_league_query(query: Query) -> Generator[List[Tuple[str, str]], None, None]:
+    for queue in query["queues"]:
+        try:
+            yield [(query["platform"].value, queue.value)]
+        except ValueError as e:
+            raise QueryValidationError from e
+
+# Grandmaster
+
+validate_grandmaster_league_query = Query. \
+    has("platform").as_(Platform).also. \
+    has("queue").as_(Queue)
+
+
+validate_many_grandmaster_league_query = Query. \
+    has("platform").as_(Platform).also. \
+    has("queues").as_(Iterable)
+
+
+def for_grandmaster_league(league: GrandmasterLeague) -> List[Tuple[str, str]]:
+    return [(league.platform.value, league.queue.value)]
+
+
+def for_grandmaster_league_query(query: Query) -> List[Tuple[str, str]]:
+    return [(query["platform"].value, query["queue"].value)]
+
+
+def for_many_grandmaster_league_query(query: Query) -> Generator[List[Tuple[str, str]], None, None]:
     for queue in query["queues"]:
         try:
             yield [(query["platform"].value, queue.value)]

--- a/cassiopeia/datastores/uniquekeys.py
+++ b/cassiopeia/datastores/uniquekeys.py
@@ -1983,7 +1983,7 @@ def for_many_match_timeline_query(query: Query) -> Generator[List[Tuple[str, int
 
 validate_current_match_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(int)
+    has("summoner.id").as_(str)
 
 
 validate_many_current_match_query = Query. \
@@ -1991,18 +1991,18 @@ validate_many_current_match_query = Query. \
     has("summoner.ids").as_(Iterable)
 
 
-def for_current_match(current_match_info: CurrentMatch) -> List[Tuple[str, int]]:
+def for_current_match(current_match_info: CurrentMatch) -> List[Tuple[str, str]]:
     # Reach into the data for the summoner ids so we don't create the Summoner objects
     # This stores the current match for every summoner in the match, so if a different summoner is
     #  requested, the match isn't pulled a second time.
     return [(current_match_info.platform.value, participant._data[CurrentGameParticipantData].summonerId) for participant in current_match_info.participants] + [(current_match_info.platform.value, current_match_info.id)]
 
 
-def for_current_match_query(query: Query) -> List[Tuple[str, int]]:
+def for_current_match_query(query: Query) -> List[Tuple[str, str]]:
     return [(query["platform"].value, query["summoner.id"])]
 
 
-def for_many_current_match_query(query: Query) -> Generator[List[Tuple[str, int]], None, None]:
+def for_many_current_match_query(query: Query) -> Generator[List[Tuple[str, str]], None, None]:
     for summoner_id in query["summoner.ids"]:
         try:
             summoner_id = int(summoner_id)

--- a/cassiopeia/datastores/uniquekeys.py
+++ b/cassiopeia/datastores/uniquekeys.py
@@ -1038,13 +1038,13 @@ def for_champion_rotation_query(query: Query) -> List[str]:
 
 validate_champion_mastery_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(str).or_("summoner.account.id").as_(str).or_("summoner.name").as_(str).also. \
+    has("summoner.id").as_(str).or_("summoner.accountId").as_(str).or_("summoner.name").as_(str).also. \
     has("champion.id").as_(int).or_("champion.name").as_(str)
 
 
 validate_many_champion_mastery_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(str).or_("summoner.account.id").as_(str).or_("summoner.name").as_(str).also. \
+    has("summoner.id").as_(str).or_("summoner.accountId").as_(str).or_("summoner.name").as_(str).also. \
     has("champions.id").as_(Iterable).or_("champions.name").as_(Iterable)
 
 
@@ -1087,10 +1087,10 @@ def for_champion_mastery_query(query: Query) -> List[Tuple]:
         keys.append((query["platform"].value, query["summoner.name"], query["champion.id"]))
     if "summoner.name" in query and "champion.name" in query:
         keys.append((query["platform"].value, query["summoner.name"], query["champion.name"]))
-    if "summoner.account.id" in query and "champion.id" in query:
-        keys.append((query["platform"].value, query["summoner.account.id"], query["champion.id"]))
-    if "summoner.account.id" in query and "champion.name" in query:
-        keys.append((query["platform"].value, query["summoner.account.id"], query["champion.name"]))
+    if "summoner.accountId" in query and "champion.id" in query:
+        keys.append((query["platform"].value, query["summoner.accountId"], query["champion.id"]))
+    if "summoner.accountId" in query and "champion.name" in query:
+        keys.append((query["platform"].value, query["summoner.accountId"], query["champion.name"]))
     return keys
 
 
@@ -1111,8 +1111,8 @@ def for_many_champion_mastery_query(query: Query) -> Generator[Tuple[str, str, s
                 keys.append((query["platform"].value, query["summoner.id"], identifier))
             if "summoner.name" in query:
                 keys.append((query["platform"].value, query["summoner.name"], identifier))
-            if "summoner.account.id" in query:
-                keys.append((query["platform"].value, query["summoner.account.id"], identifier))
+            if "summoner.accountId" in query:
+                keys.append((query["platform"].value, query["summoner.accountId"], identifier))
         if len(keys) == 0:
             raise QueryValidationError
         yield keys
@@ -1120,12 +1120,12 @@ def for_many_champion_mastery_query(query: Query) -> Generator[Tuple[str, str, s
 
 validate_champion_masteries_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(str).or_("summoner.account.id").as_(int).or_("summoner.name")
+    has("summoner.id").as_(str).or_("summoner.accountId").as_(int).or_("summoner.name")
 
 
 validate_many_champion_masteries_query = Query. \
     has("platform").as_(Platform).also. \
-    has("summoner.id").as_(str).or_("summoner.account.id").as_(int).or_("summoner.name")
+    has("summoner.id").as_(str).or_("summoner.accountId").as_(int).or_("summoner.name")
 
 
 def for_champion_masteries(champion_mastery: ChampionMasteries) -> List[Tuple]:
@@ -1151,8 +1151,8 @@ def for_champion_masteries_query(query: Query) -> List[Tuple]:
         keys.append((query["platform"].value, query["summoner.id"]))
     if "summoner.name" in query:
         keys.append((query["platform"].value, query["summoner.name"]))
-    if "summoner.account.id" in query:
-        keys.append((query["platform"].value, query["summoner.account.id"]))
+    if "summoner.accountId" in query:
+        keys.append((query["platform"].value, query["summoner.accountId"]))
     return keys
 
 
@@ -2070,12 +2070,12 @@ def for_many_featured_matches_query(query: Query) -> Generator[List[str], None, 
 
 validate_summoner_query = Query. \
     has("platform").as_(Platform).also. \
-    has("id").as_(str).or_("account.id").as_(str).or_("name").as_(str).or_("account.puuid").as_(str)
+    has("id").as_(str).or_("accountId").as_(str).or_("name").as_(str).or_("puuid").as_(str)
 
 
 validate_many_summoner_query = Query. \
     has("platform").as_(Platform).also. \
-    has("ids").as_(Iterable).or_("accounts.id").as_(Iterable).or_("names").as_(Iterable).or_("accounts.puuid").as_(Iterable)
+    has("ids").as_(Iterable).or_("accountIds").as_(Iterable).or_("names").as_(Iterable).or_("puuids").as_(Iterable)
 
 
 def for_summoner(summoner: Summoner) -> List[Tuple]:
@@ -2089,11 +2089,11 @@ def for_summoner(summoner: Summoner) -> List[Tuple]:
     except AttributeError:
         pass
     try:
-        keys.append((summoner.platform.value, "account", summoner._data[SummonerData].account.id))
+        keys.append((summoner.platform.value, "account", summoner._data[SummonerData].account_id))
     except AttributeError:
         pass
     try:
-        keys.append((summoner.platform.value, "account", summoner._data[SummonerData].account.puuid))
+        keys.append((summoner.platform.value, "account", summoner._data[SummonerData].puuid))
     except AttributeError:
         pass
     return keys
@@ -2105,10 +2105,10 @@ def for_summoner_query(query: Query) -> List[Tuple]:
         keys.append((query["platform"].value, query["id"]))
     if "name" in query:
         keys.append((query["platform"].value, query["name"]))
-    if "account.id" in query:
-        keys.append((query["platform"].value, "account", query["account.id"]))
-    if "account.puuid" in query:
-        keys.append((query["platform"].value, "account", query["account.puuid"]))
+    if "accountId" in query:
+        keys.append((query["platform"].value, "accountId", query["accountId"]))
+    if "puuid" in query:
+        keys.append((query["platform"].value, "puuid", query["puuid"]))
     return keys
 
 
@@ -2118,11 +2118,11 @@ def for_many_summoner_query(query: Query) -> Generator[List[Tuple], None, None]:
     if "ids" in query:
         grouped_identifiers.append(query["ids"])
         identifier_types.append(str)
-    elif "accounts.id" in query:
-        grouped_identifiers.append(query["accounts.id"])
+    elif "accountIds" in query:
+        grouped_identifiers.append(query["accountIds"])
         identifier_types.append(str)
-    elif "accounts.puuid" in query:
-        grouped_identifiers.append(query["accounts.puuid"])
+    elif "puuids" in query:
+        grouped_identifiers.append(query["puuids"])
         identifier_types.append(str)
     elif "names" in query:
         grouped_identifiers.append(query["names"])

--- a/cassiopeia/dto/league.py
+++ b/cassiopeia/dto/league.py
@@ -24,6 +24,8 @@ class LeaguePositionsDto(DtoObject):
 class ChallengerLeagueListDto(DtoObject):
     pass
 
+class GrandmasterLeagueListDto(DtoObject):
+    pass
 
 class MasterLeagueListDto(DtoObject):
     pass

--- a/cassiopeia/transformers/leagues.py
+++ b/cassiopeia/transformers/leagues.py
@@ -3,9 +3,9 @@ from copy import deepcopy
 
 from datapipelines import DataTransformer, PipelineContext
 
-from ..core.league import LeaguePositionData, LeaguePositionsData, LeagueEntry, LeagueEntries, LeaguesListData, LeagueListData, SummonerLeagues, League, ChallengerLeagueListData, ChallengerLeague, MasterLeagueListData, MasterLeague
+from ..core.league import LeaguePositionData, LeaguePositionsData, LeagueEntry, LeagueEntries, LeaguesListData, LeagueListData, SummonerLeagues, League, ChallengerLeagueListData, ChallengerLeague, GrandmasterLeagueListData, GrandmasterLeague, MasterLeagueListData, MasterLeague
 
-from ..dto.league import LeaguesListDto, LeagueListDto, ChallengerLeagueListDto, MasterLeagueListDto, LeaguePositionDto, LeaguePositionsDto
+from ..dto.league import LeaguesListDto, LeagueListDto, ChallengerLeagueListDto, GrandmasterLeagueListDto, MasterLeagueListDto, LeaguePositionDto, LeaguePositionsDto
 
 T = TypeVar("T")
 F = TypeVar("F")
@@ -50,6 +50,10 @@ class LeagueTransformer(DataTransformer):
     def challenger_league_list_dto_to_data(self, value: ChallengerLeagueListDto, context: PipelineContext = None) -> ChallengerLeagueListData:
         return ChallengerLeagueListData(**value)
 
+    @transform.register(GrandmasterLeagueListDto, GrandmasterLeagueListData)
+    def grandmaster_league_list_dto_to_data(self, value: GrandmasterLeagueListDto, context: PipelineContext = None) -> GrandmasterLeagueListData:
+        return GrandmasterLeagueListData(**value)
+
     @transform.register(MasterLeagueListDto, MasterLeagueListData)
     def master_league_list_dto_to_data(self, value: MasterLeagueListDto, context: PipelineContext = None) -> MasterLeagueListData:
         return MasterLeagueListData(**value)
@@ -79,6 +83,11 @@ class LeagueTransformer(DataTransformer):
     def challenger_league_list_data_to_core(self, value: ChallengerLeagueListData, context: PipelineContext = None) -> ChallengerLeague:
         data = deepcopy(value)
         return ChallengerLeague.from_data(data)
+
+    #@transform.register(GrandmasterLeagueListData, GrandmasterLeague)
+    def grandmaster_league_list_data_to_core(self, value: GrandmasterLeagueListData, context: PipelineContext = None) -> GrandmasterLeague:
+        data = deepcopy(value)
+        return GrandmasterLeague.from_data(data)
 
     #@transform.register(MasterLeagueListData, MasterLeague)
     def master_league_list_data_to_core(self, value: MasterLeagueListData, context: PipelineContext = None) -> MasterLeague:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -155,9 +155,9 @@ def test_leagues():
         #league.name
         league.id
 
-    # f"Listing all summoners in {leagues.fives.name}"
-    # for entry in leagues.fives:
-    #     entry.summoner.name, entry.league_points, leagues.fives.tier, entry.division
+    f"Listing all summoners in {leagues.fives.id}"
+    for entry in leagues.fives:
+        entry.summoner.name, entry.league_points, leagues.fives.tier, entry.division
 
     "Challenger League name and id:"
     challenger = cass.get_challenger_league(queue=Queue.ranked_solo_fives, region=region)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -4,6 +4,7 @@ import random
 import cassiopeia as cass
 from cassiopeia import Season, Queue, Summoner, Match, Champion, Champions, ChampionMastery, Item, Items, LanguageStrings, Map, Locales, Runes, Rune, RunePath, ShardStatus, FeaturedMatches, SummonerSpell, SummonerSpells, GameMode, VerificationString, Role
 
+import os, pytest
 
 def test_versions():
     versions = cass.get_versions(region="NA")
@@ -20,11 +21,9 @@ def test_realms():
 
 def test_match():
     name = "Kalturi"
-    account = 34718348
-    id = 21359666
     region = "NA"
 
-    summoner = Summoner(name=name, account=account, id=id, region=region)
+    summoner = Summoner(name=name, region=region)
 
     match_history = cass.get_match_history(summoner, queues={Queue.ranked_solo_fives})
     match_history = summoner.match_history
@@ -87,7 +86,7 @@ def test_champions():
 
 
 def test_championmastery():
-    me = Summoner(name="Kalturi", id=21359666, region="NA")
+    me = Summoner(name="Kalturi", region="NA")
     karma = Champion(name="Karma", id=43, region="NA")
     cm = ChampionMastery(champion=karma, summoner=me, region="NA")
     cm = cass.get_champion_mastery(champion=karma, summoner=me, region="NA")
@@ -125,7 +124,6 @@ def test_languagestrings():
     language_strings = cass.get_language_strings(region="NA")
     assert len(language_strings.strings) > 0
 
-
 def test_leagues():
     summoner_name = "Spartan324"
     region = "NA"
@@ -145,24 +143,36 @@ def test_leagues():
     else:
         "The summoner is not in their promos."
 
-    "Name of leagues this summoner is in:"
+    "Name and id of leagues this summoner is in:"
     for league in positions:
         league.name
+        league.league_id
 
-    # leagues = cass.get_leagues(summoner)
+    leagues = cass.get_leagues(summoner)
     leagues = summoner.leagues
     "Name of leagues this summoner is in (called from a different endpoint):"
     for league in leagues:
-        league.name
+        #league.name
+        league.id
 
-    f"Listing all summoners in {leagues.fives.name}"
-    for entry in leagues.fives:
-        entry.summoner.name, entry.league_points, leagues.fives.tier, entry.division
+    # f"Listing all summoners in {leagues.fives.name}"
+    # for entry in leagues.fives:
+    #     entry.summoner.name, entry.league_points, leagues.fives.tier, entry.division
 
-    "Challenger League name:"
+    "Challenger League name and id:"
     challenger = cass.get_challenger_league(queue=Queue.ranked_solo_fives, region=region)
-    challenger.name
+    # challenger.name
+    challenger.id
 
+    "Grandmaster League name and id:"
+    grandmaster = cass.get_grandmaster_league(queue=Queue.ranked_solo_fives, region=region)
+    # grandmaster.name
+    grandmaster.id
+
+    "Master League name and id:"
+    master = cass.get_master_league(queue=Queue.ranked_solo_fives, region=region)
+    # master.name
+    master.id
 
 def test_locales():
     locales = cass.get_locales(region="NA")
@@ -243,7 +253,7 @@ def test_summoner():
 
 
 def test_verification_string():
-    summoner = Summoner(id=21359666, region="NA")
+    summoner = Summoner(name="Kalturi", region="NA")
     vs1 = summoner.verification_string
     vs = VerificationString(summoner=summoner, region="NA")
     vs2 = vs.string
@@ -263,10 +273,8 @@ def test_summonerspells():
 
 def test_timeline():
     name = "Kalturi"
-    account = 34718348
-    id = 21359666
     region = "NA"
-    summoner = Summoner(name=name, account=account, id=id, region=region)
+    summoner = Summoner(name=name, region=region)
     match_history = summoner.match_history
     match = match_history[0]
     'Match ID:', match.id
@@ -282,6 +290,8 @@ def test_timeline():
 
 
 def test_championgg():
+    if not "CHAMPIONGG_KEY" in os.environ:
+        pytest.xfail("No championgg key provided")
     syndra = Champion(name="Syndra", region="NA")
     syndra.name
     syndra.championgg[Role.middle].win_rate

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -43,13 +43,13 @@ def test_match():
     match.id
 
     p = match.participants[summoner]
-    p.id, p.summoner.region, p.summoner.account.id, p.summoner.name, p.summoner.id, p.champion.id
+    p.id, p.summoner.region, p.summoner.account_id, p.summoner.name, p.summoner.id, p.champion.id
 
     for p in match.participants:
-        p.id, p.summoner.region, p.summoner.account.id, p.summoner.name, p.summoner.id, p.champion.id, p.team.first_dragon
+        p.id, p.summoner.region, p.summoner.account_id, p.summoner.name, p.summoner.id, p.champion.id, p.team.first_dragon
 
     for p in match.participants:
-        p.id, p.summoner.region, p.summoner.account.id, p.summoner.name, p.summoner.id, p.champion.id, p.team.first_dragon
+        p.id, p.summoner.region, p.summoner.account_id, p.summoner.name, p.summoner.id, p.champion.id, p.team.first_dragon
 
     match.blue_team.win
     match.red_team.win
@@ -243,7 +243,7 @@ def test_summoner():
     summoner = Summoner(name=name, region=region)
     "Name:", summoner.name
     "ID:", summoner.id
-    "Account ID:", summoner.account.id
+    "Account ID:", summoner.account_id
     "Level:", summoner.level
     "Revision date:", summoner.revision_date
     "Profile icon ID:", summoner.profile_icon.id

--- a/test/test_map_location.py
+++ b/test/test_map_location.py
@@ -11,7 +11,7 @@ def test_summonersrift_map():
 
 
 def test_from_match():
-    summoner = Summoner(name="Kalturi", id=21359666, account=Account(id=34718348), region="NA")
+    summoner = Summoner(name="Kalturi", region="NA")
     match_history = summoner.match_history
 
     match = match_history[0]

--- a/test/test_matchhistory.py
+++ b/test/test_matchhistory.py
@@ -6,49 +6,49 @@ from cassiopeia import Season, Queue, Summoner
 
 def test_match_history_1():
     region = "NA"
-    summoner = Summoner(name="Kalturi", account=34718348, id=21359666, region=region)
+    summoner = Summoner(name="Kalturi", region=region)
     match_history = cass.get_match_history(summoner=summoner, queues={Queue.ranked_solo_fives})
     assert len(match_history) > 400
 
 
 def test_match_history_2():
     region = "NA"
-    summoner = Summoner(name="Kalturi", account=34718348, id=21359666, region=region)
+    summoner = Summoner(name="Kalturi", region=region)
     match_history = cass.get_match_history(summoner=summoner, seasons={Season.season_8}, queues={Queue.ranked_solo_fives}, begin_time=arrow.now().shift(days=-140), end_time=arrow.now())
     assert len(match_history) > 0
 
 
 def test_match_history_3():
     region = "NA"
-    summoner = Summoner(name="Kalturi", account=34718348, id=21359666, region=region)
+    summoner = Summoner(name="Kalturi", region=region)
     match_history = cass.get_match_history(summoner=summoner, queues={Queue.ranked_solo_fives}, begin_time=arrow.get(2017, 2, 7), end_time=arrow.get(2017, 2, 14))
     assert len(match_history) == 16
 
 
 def test_match_history_4():
     region = "NA"
-    summoner = Summoner(name="Kalturi", account=34718348, id=21359666, region=region)
+    summoner = Summoner(name="Kalturi", region=region)
     match_history = cass.get_match_history(summoner=summoner, seasons={Season.season_8}, queues={Queue.ranked_solo_fives}, begin_time=arrow.get(2016, 1, 1), end_time=arrow.get(2016, 1, 11))
     assert len(match_history) == 0
 
 
 def test_match_history_5():
     region = "NA"
-    summoner = Summoner(name="Kalturi", account=34718348, id=21359666, region=region)
+    summoner = Summoner(name="Kalturi", region=region)
     match_history = cass.get_match_history(summoner=summoner, seasons={Season.season_8}, queues={Queue.ranked_solo_fives}, begin_time=arrow.get(2016, 1, 1), end_time=arrow.now())
     assert len(match_history) > 0
 
 
 def test_match_history_6():
     region = "NA"
-    summoner = Summoner(name="Kalturi", account=34718348, id=21359666, region=region)
+    summoner = Summoner(name="Kalturi", region=region)
     match_history = cass.get_match_history(summoner=summoner, queues={Queue.ranked_solo_fives}, begin_time=arrow.get(2016, 12, 1), end_time=arrow.get(2016, 12, 30))
     assert len(match_history) > 0
 
 
 def test_match_history_7():
     region = "NA"
-    summoner = Summoner(name="Kalturi", account=34718348, id=21359666, region=region)
+    summoner = Summoner(name="Kalturi", region=region)
     match_history = cass.get_match_history(summoner=summoner, seasons={Season.season_8}, queues={Queue.ranked_solo_fives}, begin_time=arrow.get(2016, 12, 1))
     assert len(match_history) > 0
 

--- a/test/test_summoner.py
+++ b/test/test_summoner.py
@@ -8,7 +8,6 @@ from .constants import SUMMONER_NAME, UNKNOWN_SUMMONER_NAME
 
 def test_unknown_summoner():
     assert not cassiopeia.get_summoner(name=UNKNOWN_SUMMONER_NAME, region="NA").exists
-    assert not cassiopeia.get_summoner(id=9999999999999, region="NA").exists
 
 
 def test_equal_summoners():


### PR DESCRIPTION
This PR updates the summoner, match, champion, league, spectator and third-party-code endpoints to v4.
The other endpoints don't need any update, as they haven't changed.

It also includes the addtion of the new grandmaster league endpoint.