### PR TITLE
participant role lane bugfix

### DIFF
--- a/cassiopeia/core/match.py
+++ b/cassiopeia/core/match.py
@@ -1275,11 +1275,11 @@ class Participant(CassiopeiaObject):
 
     @property
     def lane(self) -> Lane:
-        return Lane.from_match_naming_scheme(self._data[ParticipantData].stats.lane)
+        return Lane.from_match_naming_scheme(self._data[ParticipantData].timeline.lane)
 
     @property
     def role(self) -> Role:
-        return Role.from_match_naming_scheme(self._data[ParticipantData].stats.role)
+        return Role.from_match_naming_scheme(self._data[ParticipantData].timeline.role)
 
     @property
     def skill_order(self) -> List[Key]:


### PR DESCRIPTION
Fixes the following bug:
AttributeError: 'ParticipantStatsData' object has no attribute 'role'