### PR TITLE
Quickfix fixes meraki-analytics/cassiopeia#223

### DIFF
--- a/cassiopeia/datastores/ddragon.py
+++ b/cassiopeia/datastores/ddragon.py
@@ -423,7 +423,8 @@ class DDragon(DataSource):
         for path in body:
             for tier, subpath in enumerate(path["slots"]):
                 for i, rune in enumerate(subpath["runes"]):
-                    rune["path"] = path["name"]
+                    rune["path"] = path["key"]
+                    rune["path_name"] = path["name"]
                     rune["tier"] = tier
                     subpath[i] = RuneDto(rune)
 


### PR DESCRIPTION
This is just a quick fix for issue #223 
It now uses the runepath key instead of the name, to reference the runepath as the key always uses the english name. In addition it adds a new field path_name to the rune itself.

We might want to consider to load the runepath from ddragon, instead of having it as a constant, but I'm not sure how that should be done. If that's what should be done, let me know how to do it and i will change the PR accordingly.