### PR TITLE
Remove pycurl requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,10 @@ import sys
 
 from setuptools import setup, find_packages
 
-
 install_requires = [
     "datapipelines>=1.0.6",
     "merakicommons>=1.0.6",
     "Pillow",
-    "pycurl",
     "arrow"
 ]
 
@@ -19,7 +17,7 @@ if sys.version_info.major != 3 and sys.version_info.minor != 6:
 
 setup(
     name="cassiopeia",
-    version="4.0.1",  # Keep the Cass version at parity with the Riot API major version, use the minor version for breaking changes, and the patch version for everything else
+    version="4.0.1", # Keep the Cass version at parity with the Riot API major version, use the minor version for breaking changes, and the patch version for everything else
     author="Jason Maldonis; Rob Rua",
     author_email="team@merakianalytics.com",
     url="https://github.com/meraki-analytics/cassiopeia",


### PR DESCRIPTION
Fixes #273 

Should Python 3.7 also be allowed?