### PR TITLE
Fix crash when getting summoner entries with default region config

### DIFF
--- a/cassiopeia/core/league.py
+++ b/cassiopeia/core/league.py
@@ -280,7 +280,6 @@ class LeagueSummonerEntries(CassiopeiaLazyList):
         CassiopeiaObject.__init__(self, **kwargs)
 
     @classmethod
-    @provide_default_region
     def __get_query_from_kwargs__(cls, *, summoner: Union[Summoner, str]) -> dict:
         query = {"region": summoner.region}
         if isinstance(summoner, Summoner):

--- a/test/test_summoner.py
+++ b/test/test_summoner.py
@@ -18,3 +18,12 @@ def test_equal_summoners():
     assert from_name.name == from_id.name
     assert from_name == from_id
     assert from_name.to_dict() == from_id.to_dict()
+
+
+def test_can_get_league_entries():
+    config_backup = cassiopeia.configuration.settings
+    cassiopeia.apply_settings({"global": {"default_region": "NA"}})
+    summoner = cassiopeia.Summoner(name=SUMMONER_NAME)
+    summoner.league_entries
+    # restore global settings to not affect other tests if they are run in one session
+    cassiopeia.apply_settings(config_backup)


### PR DESCRIPTION
Fixes #286 
The decorator at https://github.com/meraki-analytics/cassiopeia/blob/master/cassiopeia/core/league.py#L283 puts the default region (which was specified in config) in the `kwargs` dict during patching of  `__get_query_from_kwargs__` class method of  `LeagueSummonerEntries` which has no keyword `region`. 

When no default region was specified it works fine because it doesn't place anything in the `kwargs` dict. 

Removing this decorator fixes this crash and the function still works perfectly fine because when there is no default the region is set at https://github.com/meraki-analytics/cassiopeia/blob/master/cassiopeia/core/league.py#L285 and when when there is a default the region is set during `Summoner` construction through the `@provide_default_region` decoration on its constructor