### PR TITLE
Fix Leagues; Add some tests

### DIFF
--- a/cassiopeia/core/league.py
+++ b/cassiopeia/core/league.py
@@ -144,6 +144,12 @@ class LeagueEntry(CassiopeiaGhost):
 
     __hash__ = CassiopeiaGhost.__hash__
 
+    @classmethod
+    def from_data(cls, data: LeagueEntryData, league: "League" = None):
+        self = super().from_data(data)
+        self.__league = league
+        return self
+
     @lazy_property
     def region(self) -> Region:
         """The region for this champion."""
@@ -156,15 +162,24 @@ class LeagueEntry(CassiopeiaGhost):
 
     @property
     def league_id(self) -> str:
-        return self._data[LeagueEntryData].leagueId
+        try:
+            return self._data[LeagueEntryData].leagueId
+        except AttributeError:
+            return self.league.id
 
     @lazy_property
     def queue(self) -> Queue:
-        return Queue(self._data[LeagueEntryData].queue)
+        try:
+            return Queue(self._data[LeagueEntryData].queue)
+        except AttributeError:
+            return self.league.queue
 
     @property
     def name(self) -> str:
-        return self._data[LeagueEntryData].name
+        try:
+            return self._data[LeagueEntryData].name
+        except AttributeError:
+            return self.league.name
 
     @lazy_property
     def tier(self) -> Tier:
@@ -211,7 +226,7 @@ class LeagueEntry(CassiopeiaGhost):
 
     @lazy_property
     def league(self) -> "League":
-        return League(id=self.league_id, region=self.region)
+        return self.__league or League(id=self.league_id, region=self.region)
 
     @property
     def league_points(self) -> int:
@@ -391,7 +406,7 @@ class League(CassiopeiaGhost):
     @ghost_load_on
     @lazy
     def entries(self) -> List[LeagueEntry]:
-        return SearchableList([LeagueEntry.from_data(entry) for entry in self._data[LeagueData].entries])
+        return SearchableList([LeagueEntry.from_data(entry, self) for entry in self._data[LeagueData].entries])
 
 
 class ChallengerLeague(League):

--- a/cassiopeia/core/league.py
+++ b/cassiopeia/core/league.py
@@ -160,26 +160,12 @@ class LeagueEntry(CassiopeiaGhost):
         """The platform for this champion."""
         return self.region.platform
 
-    @property
-    def league_id(self) -> str:
-        try:
-            return self._data[LeagueEntryData].leagueId
-        except AttributeError:
-            return self.league.id
-
     @lazy_property
     def queue(self) -> Queue:
         try:
             return Queue(self._data[LeagueEntryData].queue)
         except AttributeError:
             return self.league.queue
-
-    @property
-    def name(self) -> str:
-        try:
-            return self._data[LeagueEntryData].name
-        except AttributeError:
-            return self.league.name
 
     @lazy_property
     def tier(self) -> Tier:
@@ -226,7 +212,7 @@ class LeagueEntry(CassiopeiaGhost):
 
     @lazy_property
     def league(self) -> "League":
-        return self.__league or League(id=self.league_id, region=self.region)
+        return self.__league or League(id=self._data[LeagueEntryData].leagueId, region=self.region)
 
     @property
     def league_points(self) -> int:

--- a/cassiopeia/core/summoner.py
+++ b/cassiopeia/core/summoner.py
@@ -209,3 +209,10 @@ class Summoner(CassiopeiaGhost):
         from .thirdpartycode import VerificationString
         vs = VerificationString(summoner=self, region=self.region)
         return vs.string
+
+    @lazy_property
+    def ranks(self):
+        ranks = {}
+        for position in self.league_entries:
+            ranks[position.queue] = Rank(tier=position.tier, division=position.division)
+        return ranks

--- a/cassiopeia/core/summoner.py
+++ b/cassiopeia/core/summoner.py
@@ -209,10 +209,3 @@ class Summoner(CassiopeiaGhost):
         from .thirdpartycode import VerificationString
         vs = VerificationString(summoner=self, region=self.region)
         return vs.string
-
-    @lazy_property
-    def ranks(self):
-        ranks = {}
-        for position in self.league_positions:
-            ranks[position.queue] = Rank(tier=position.tier, division=position.division)
-        return ranks

--- a/test/constants.py
+++ b/test/constants.py
@@ -13,3 +13,6 @@ UNKNOWN_SUMMONER_NAME = "abcaklsjdlakakdjlsakjdsdjlaksjdla"
 
 # Champion name used for validating champion-related endpoints
 CHAMP_NAME = "Karma"
+
+# League UUID for validating league-related endpoints
+LEAGUE_UUID = "58d9b5e0-2031-11e9-b995-c81f66cf2333"

--- a/test/test_league.py
+++ b/test/test_league.py
@@ -1,0 +1,46 @@
+import os
+import unittest
+
+from cassiopeia import cassiopeia
+from .constants import LEAGUE_UUID, UNKNOWN_SUMMONER_NAME
+
+
+class TestLeague(unittest.TestCase):
+    def setUp(self):
+        cassiopeia.apply_settings(cassiopeia.get_default_config())
+        cassiopeia.set_riot_api_key(os.environ.get('RIOT_API_KEY'))
+        cassiopeia.apply_settings({"global": {"default_region": "NA"}})
+
+    def test_access_league_properties(self):
+        lg = cassiopeia.League(id=LEAGUE_UUID)
+        self.assertIsNotNone(lg.region)
+        self.assertIsNotNone(lg.platform)
+        self.assertEqual(lg.id, LEAGUE_UUID)
+        self.assertIsNotNone(lg.tier)
+        self.assertIsNotNone(lg.queue)
+        self.assertIsNotNone(lg.name)
+        self.assertIsNotNone(lg.entries)
+
+    def test_access_league_entry_properties(self):
+        entry = cassiopeia.League(id=LEAGUE_UUID).entries[0]
+        self.assertIsNotNone(entry.region)
+        self.assertIsNotNone(entry.platform)
+        self.assertIsNotNone(entry.league_id)
+        self.assertIsNotNone(entry.queue)
+        self.assertIsNotNone(entry.name)
+        self.assertIsNotNone(entry.tier)
+        self.assertIsNotNone(entry.division)
+        self.assertIsNotNone(entry.hot_streak)
+        self.assertIsNotNone(entry.wins)
+        self.assertIsNotNone(entry.veteran)
+        self.assertIsNotNone(entry.losses)
+        self.assertIsNotNone(entry.summoner)
+        self.assertIsNotNone(entry.fresh_blood)
+        self.assertEqual(entry.league, cassiopeia.League(id=LEAGUE_UUID))
+        self.assertIsNotNone(entry.league_points)
+        self.assertIsNotNone(entry.inactive)
+        # self.assertIsNotNone(entry.role)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_league.py
+++ b/test/test_league.py
@@ -1,8 +1,10 @@
+import io
 import os
 import unittest
+from unittest.mock import patch
 
 from cassiopeia import cassiopeia
-from .constants import LEAGUE_UUID, UNKNOWN_SUMMONER_NAME
+from .constants import LEAGUE_UUID, SUMMONER_NAME
 
 
 class TestLeague(unittest.TestCase):
@@ -25,9 +27,7 @@ class TestLeague(unittest.TestCase):
         entry = cassiopeia.League(id=LEAGUE_UUID).entries[0]
         self.assertIsNotNone(entry.region)
         self.assertIsNotNone(entry.platform)
-        self.assertIsNotNone(entry.league_id)
         self.assertIsNotNone(entry.queue)
-        self.assertIsNotNone(entry.name)
         self.assertIsNotNone(entry.tier)
         self.assertIsNotNone(entry.division)
         self.assertIsNotNone(entry.hot_streak)
@@ -40,6 +40,24 @@ class TestLeague(unittest.TestCase):
         self.assertIsNotNone(entry.league_points)
         self.assertIsNotNone(entry.inactive)
         # self.assertIsNotNone(entry.role)
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_get_id_no_call_to_league(self, patched_log):
+        s = cassiopeia.Summoner(name=SUMMONER_NAME)
+        s.league_entries[0].league.id
+        full_http_call_log = patched_log.getvalue()
+        log_lines = full_http_call_log.splitlines()
+
+        # check that there were 2 http calls: one to get summoner and one to get league entries
+        self.assertEqual(len(log_lines), 2)
+        get_summoner_call = log_lines[0]
+        get_league_entries_call = log_lines[1]
+
+        self.assertTrue('summoner/v4/summoners/by-name' in get_summoner_call)
+        self.assertTrue('league/v4/entries/by-summoner' in get_league_entries_call)
+
+        # check that league endpoint wasn't called to get id
+        self.assertFalse('league/v4/leagues' in full_http_call_log)
 
 
 if __name__ == "__main__":

--- a/test/test_summoner.py
+++ b/test/test_summoner.py
@@ -13,7 +13,7 @@ class TestSummoner(unittest.TestCase):
         cassiopeia.apply_settings({"global": {"default_region": "NA"}})
 
     def test_unknown_summoner(self):
-        for e in cassiopeia.Summoner(name="Kalturi", region="NA").league_entries: print(e.name)
+        for e in cassiopeia.Summoner(name="Kalturi", region="NA").league_entries: print(e.league.name)
         self.assertFalse(cassiopeia.get_summoner(name=UNKNOWN_SUMMONER_NAME, region="NA").exists)
 
     def test_ranks(self):

--- a/test/test_summoner.py
+++ b/test/test_summoner.py
@@ -16,6 +16,13 @@ class TestSummoner(unittest.TestCase):
         for e in cassiopeia.Summoner(name="Kalturi", region="NA").league_entries: print(e.name)
         self.assertFalse(cassiopeia.get_summoner(name=UNKNOWN_SUMMONER_NAME, region="NA").exists)
 
+    def test_ranks(self):
+        s = cassiopeia.Summoner(name=SUMMONER_NAME)
+        ranks = s.ranks
+        for key in ranks:
+            self.assertIsInstance(key, cassiopeia.Queue)
+            self.assertIsInstance(ranks[key], cassiopeia.data.Rank)
+
     def test_access_properties(self):
         s = cassiopeia.Summoner(name=SUMMONER_NAME)
         self.assertIsNotNone(s.region)


### PR DESCRIPTION
1.  Fix #291 - remove `league_positions` since it is no longer in api-v4
2.  Fix #290 - It wasn't just name, there were a number of properties that caused a crash because they are not available in the `LeagueItemDTO` return object from the API. `LeagueItemDTO` doesn't even have a `leagueId`, so `LeagueEntry` was changed to add the option to pass in a `League` object on creation, which is used when `LeagueEntry` is created from a `LeagueItemDTO` rather than a `LeagueEntryDTO`. In both these cases, `LeagueEntry.league_id`, `LeagueEntry.queue`. `LeagueEntry.name`,`LeagueEntry.league`, no longer crash on access.
3.  Added some simple test cases that just try to access every available property to make sure none of them cause a crash (running this test case is how I discovered the other 3 properties that cause a crash on access)