### PR TITLE
Fix `RiotAPI` key in pipeline settings docs

### DIFF
--- a/doc/settings.rst
+++ b/doc/settings.rst
@@ -64,7 +64,7 @@ Below is an example, and these settings are the default if any value is not spec
 
 .. code-block:: json
 
-    "Riot API": {
+    "RiotAPI": {
         "api_key": "RIOT_API_KEY",
         "limiting_share": 1.0,
         "request_error_handling": {


### PR DESCRIPTION
`Riot API` -> `RiotAPI` as the snippet was showing invalid Cass settings, which in turn resulted in:

```python
AttributeError: module 'cassiopeia.datastores' has no attribute 'Riot API'
```