### PR TITLE
Update League Examples to Use League Entries

### DIFF
--- a/examples/leagues.py
+++ b/examples/leagues.py
@@ -8,27 +8,26 @@ def print_leagues(summoner_name: str, region: str):
     print("Name:", summoner.name)
     print("ID:", summoner.id)
 
-    # positions = cass.get_league_positions(summoner, region=region)
-    positions = summoner.league_positions
-    if positions.fives.promos is not None:
+    # entries = cass.get_league_entries(summoner, region=region)
+    entries = summoner.league_entries
+    if entries.fives.promos is not None:
         # If the summoner is in their promos, print some info
-        print("Promos progress:", positions.fives.promos.progress)
-        print("Promos wins", positions.fives.promos.wins)
-        print("Promos losses:", positions.fives.promos.losses)
-        print("Games not yet played in promos:", positions.fives.promos.not_played)
-        print("Number of wins required to win promos:", positions.fives.promos.wins_required)
+        print("Promos progress:", entries.fives.promos.progress)
+        print("Promos wins", entries.fives.promos.wins)
+        print("Promos losses:", entries.fives.promos.losses)
+        print("Games not yet played in promos:", entries.fives.promos.not_played)
+        print("Number of wins required to win promos:", entries.fives.promos.wins_required)
     else:
         print("The summoner is not in their promos.")
 
     print("Name of leagues this summoner is in:")
-    for league in positions:
-        print(league.name)
+    for entry in entries:
+        print(entry.league.name)
     print()
 
-    leagues = summoner.leagues
     print(f"Listing all summoners in this league:")
-    for entry in leagues.fives[Position.utility]:
-        print(entry.summoner.name, entry.league_points, entry.tier, entry.division, entry.position)
+    for position, entry in enumerate(entries.fives.league.entries):
+        print(entry.summoner.name, entry.league_points, entry.tier, entry.division, position)
 
     print()
     print("Master's League name:")

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -125,28 +125,28 @@ def test_languagestrings():
     assert len(language_strings.strings) > 0
 
 def test_leagues():
-    summoner_name = "Spartan324"
+    summoner_name = "Kalturi"
     region = "NA"
     summoner = Summoner(name=summoner_name, region=region)
     "Name:", summoner.name
     "ID:", summoner.id
 
-    # positions = cass.get_league_positions(summoner, region=region)
-    positions = summoner.league_positions
-    if positions.fives.promos is not None:
+    # entries = cass.get_league_entries(summoner, region=region)
+    entries = summoner.league_entries
+    if entries.fives.promos is not None:
         # If the summoner is in their promos, print some info
-        "Promos progress:", positions.fives.promos.progress
-        "Promos wins", positions.fives.promos.wins
-        "Promos losses:", positions.fives.promos.losses
-        "Games not yet played in promos:", positions.fives.promos.not_played
-        "Number of wins required to win promos:", positions.fives.promos.wins_required
+        "Promos progress:", entries.fives.promos.progress
+        "Promos wins", entries.fives.promos.wins
+        "Promos losses:", entries.fives.promos.losses
+        "Games not yet played in promos:", entries.fives.promos.not_played
+        "Number of wins required to win promos:", entries.fives.promos.wins_required
     else:
         "The summoner is not in their promos."
 
     "Name and id of leagues this summoner is in:"
-    for league in positions:
-        league.name
-        league.league_id
+    for entry in entries:
+        entry.league.name
+        entry.league.id
 
     leagues = cass.get_leagues(summoner)
     leagues = summoner.leagues


### PR DESCRIPTION
While looking into #302 , I noticed that the leagues examples still refer to `league_positions` instead of the new `league_entries` (see [here](https://github.com/meraki-analytics/cassiopeia/commit/becf9b0e4703b40d0cf1e279eeb7777c421b7f48#diff-1a215be1e9c27aa2ab3d00c4963a889d)) and thus the examples don't actually work anymore. This PR updates the examples to use the new endpoint's conventions. Now we get the correct output instead of an error.

Before:
```
Name: Kalturi
Making call: https://na1.api.riotgames.com/lol/summoner/v4/summoners/by-name/Kalturi
Traceback (most recent call last):
  File "/cassiopeia/examples/leagues.py", line 42, in <module>
    print_leagues("Kalturi", "NA")
  File "/cassiopeia/examples/leagues.py", line 15, in print_leagues
    positions = summoner.league_positions
AttributeError: 'Summoner' object has no attribute 'league_positions'
```

After:
```
Name: Kalturi
Making call: https://na1.api.riotgames.com/lol/summoner/v4/summoners/by-name/Kalturi
ID: Kt1ODigb0dtfcEu3jzcFheH3r60lJhpcShyTATzVEs4hrDQ
Making call: https://na1.api.riotgames.com/lol/league/v4/entries/by-summoner/Kt1ODigb0dtfcEu3jzcFheH3r60lJhpcShyTATzVEs4hrDQ
The summoner is not in their promos.
Name of leagues this summoner is in:
Making call: https://na1.api.riotgames.com/lol/league/v4/leagues/19818a50-93e3-11e9-9959-c81f66cf2333
Poppy's Lords
Making call: https://na1.api.riotgames.com/lol/league/v4/leagues/8be03140-afc3-11e9-a3fc-c81f66cf2333
Poppy's Chosen

Listing all summoners in this league:
TrueNorthSupport 84 Gold IV 0
RecklessRaven 93 Gold IV 1
AwkwardMorning 33 Gold II 2
FhMS1nito3 39 Gold IV 3

...

Master's League name:
Making call: https://na1.api.riotgames.com/lol/league/v4/masterleagues/by-queue/RANKED_SOLO_5x5
Jarvan IV's Elementalists
```

I also made some similar updates in the tests. The test I changed still needs some more work -- it still errors out, just now on the `cass.get_leagues(summoner)` call on l151 instead of further up. Let me know if you would prefer me take these changes out of this PR and open up another to fully fix that test.