### PR TITLE
Fix item loading for older versions of the game.

### DIFF
--- a/cassiopeia/core/staticdata/item.py
+++ b/cassiopeia/core/staticdata/item.py
@@ -53,7 +53,7 @@ class ItemData(CoreData):
             self.buildsFrom = [int(x) for x in kwargs.pop("from")]
         if "stats" in kwargs:
             self.stats = ItemStatsData(**kwargs.pop("stats"))
-        if "colloq" in kwargs:
+        if "colloq" in kwargs and kwargs["colloq"] is not None:
             self.keywords = set(kw for kw in kwargs.pop("colloq").split(";") if kw != "")
         if "maps" in kwargs:
             """List of maps where this item is available."""

--- a/test/test_items.py
+++ b/test/test_items.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+
+import cassiopeia
+
+class TestItems(unittest.TestCase):
+    def setUp(self):
+        cassiopeia.apply_settings(cassiopeia.get_default_config())
+        cassiopeia.set_riot_api_key(os.environ.get('RIOT_API_KEY'))
+        cassiopeia.apply_settings({"global": {"default_region": "NA"}})
+
+    def test_items_from_different_versions(self):
+        versions = [cassiopeia.Versions()[0], "6.5.1"]
+
+        for version in versions:
+            with self.subTest(version=version):
+                items = cassiopeia.Items(version=version)
+                self.assertIsNotNone(items.region)
+                self.assertIsNotNone(items.version)
+
+                item = items[0]
+                self.assertIsNotNone(item.id)
+
+


### PR DESCRIPTION
In older versions of the League of Legends, e.g. 6.5.1, jungle item
enchantments "colloq" field was set to nill. This went unnoticed through
parser and caused an error when trying to load the items.

Quick repro of a bug:
```python
import cassiopeia as cass

items = cass.Items(region='NA', version='6.5.1')
```

This patch treats nill values in "colloq" field (None in Python) by
ignoring them as if the field was not set at all.