### PR TITLE
Fix support items via timeline and add type hints

### DIFF
--- a/cassiopeia/cassiopeia.py
+++ b/cassiopeia/cassiopeia.py
@@ -69,7 +69,7 @@ def get_challenger_league(queue: Union[Queue, int, str], region: Union[Region, s
 def get_match_history(summoner: Summoner, begin_index: int = None, end_index: int = None, begin_time: arrow.Arrow = None, end_time: arrow.Arrow = None, queues: Set[Queue] = None, seasons: Set[Season] = None, champions: Set[Champion] = None):
     return MatchHistory(summoner=summoner, begin_index=begin_index, end_index=end_index, begin_time=begin_time, end_time=end_time, queues=queues, seasons=seasons, champions=champions)
 
-def get_match(id, region: Union[Region, str] = None) -> Match:
+def get_match(id : int, region: Union[Region, str] = None) -> Match:
     return Match(id=id, region=region)
 
 

--- a/cassiopeia/core/match.py
+++ b/cassiopeia/core/match.py
@@ -874,6 +874,12 @@ class _ItemState:
         items_to_ignore = (2010, 3599, 3520, 3513, 2422, 2052)
         # 2422 is Slightly Magical Boots... I could figure out how to add those and Biscuits to the inventory based on runes but it would be manual...
         # 2052 is Poro-Snax, which gets added to inventory eventless
+        upgradable_items = {
+            3850: 3851, 3851: 3853, # Spellthief's Edge -> Frostfang -> Shard of True Ice
+            3854: 3855, 3855: 3857, # Steel Shoulderguards -> Runesteel Spaulders -> Pauldrons of Whiterock
+            3858: 3859, 3859: 3860, # Relic Shield -> Targon's Buckler -> Bulwark of the Mountain
+            3862: 3863, 3863: 3864, # Spectral Sickle -> Harrowing Crescent -> Black Mist Scythe
+        }
         item_id = getattr(event, 'item_id', getattr(event, 'before_id', None))
         assert item_id is not None
         if item_id in items_to_ignore:
@@ -883,6 +889,9 @@ class _ItemState:
             self._events.append(event)
         elif event.type == "ITEM_DESTROYED":
             self.destroy(event.item_id)
+            if event.item_id in upgradable_items:
+                # add the upgraded item
+                self.add(upgradable_items[event.item_id])
             self._events.append(event)
         elif event.type == "ITEM_SOLD":
             self.destroy(event.item_id)

--- a/cassiopeia/core/match.py
+++ b/cassiopeia/core/match.py
@@ -871,8 +871,9 @@ class _ItemState:
         return str(self._items)
 
     def process_event(self, event):
-        items_to_ignore = (2010, 3599, 3520, 3513, 2422)
+        items_to_ignore = (2010, 3599, 3520, 3513, 2422, 2052)
         # 2422 is Slightly Magical Boots... I could figure out how to add those and Biscuits to the inventory based on runes but it would be manual...
+        # 2052 is Poro-Snax, which gets added to inventory eventless
         item_id = getattr(event, 'item_id', getattr(event, 'before_id', None))
         assert item_id is not None
         if item_id in items_to_ignore:


### PR DESCRIPTION
In the current version of cassiopeia, support items will raise ValueError's due to the items being destroyed from the inventory, but never added. This change adds support items to player item lists when they are destroyed (since this is when they are upgraded, the item would be sold otherwise).
Use of Poro-Snax also raises ValueError's since they are added to a player's inventory with no ITEM event, so they are added to the ignore list since they have no analytically valuable effect. It's worth noting that Poro-Snax could be accurately tracked via the tower destroyed event while also checking that the map is Howling Abyss, but the feature seemed too niche to be worth implementing.
The type-hint for `cass.get_match()` should have the docs generate with the `id` argument correctly. Currently, the docs only show that `get_match` takes in a single optional string.