### PR TITLE
Update usage of arrow, removing need for version pin

### DIFF
--- a/cassiopeia/core/match.py
+++ b/cassiopeia/core/match.py
@@ -282,10 +282,10 @@ class MatchHistory(CassiopeiaLazyList):  # type: List[Match]
         kwargs["begin_index"] = begin_index
         kwargs["end_index"] = end_index
         if begin_time is not None and not isinstance(begin_time, (int, float)):
-            begin_time = begin_time.timestamp * 1000
+            begin_time = begin_time.int_timestamp * 1000
         kwargs["begin_time"] = begin_time
         if end_time is not None and not isinstance(end_time, (int, float)):
-            end_time = end_time.timestamp * 1000
+            end_time = end_time.int_timestamp * 1000
         kwargs["end_time"] = end_time
         assert isinstance(summoner, Summoner)
         self.__account_id_callable = lambda: summoner.account_id
@@ -306,12 +306,12 @@ class MatchHistory(CassiopeiaLazyList):  # type: List[Match]
 
         if begin_time is not None:
             if isinstance(begin_time, arrow.Arrow):
-                begin_time = begin_time.timestamp * 1000
+                begin_time = begin_time.int_timestamp * 1000
             query["beginTime"] = begin_time
 
         if end_time is not None:
             if isinstance(end_time, arrow.Arrow):
-                end_time = end_time.timestamp * 1000
+                end_time = end_time.int_timestamp * 1000
             query["endTime"] = end_time
 
         if queues is not None:

--- a/cassiopeia/datastores/ghost.py
+++ b/cassiopeia/datastores/ghost.py
@@ -417,7 +417,7 @@ class UnloadedGhostStore(DataSource):
                     "seasons": seasons,
                     "champion.ids": champion_ids,
                     "beginIndex": _begin_index,
-                    "beginTime": _current_first_requested_dt.timestamp * 1000,
+                    "beginTime": _current_first_requested_dt.int_timestamp * 1000,
                     "maxNumberOfMatches": max_number_of_requested_matches
                 }
                 if "endTime" in original_query:

--- a/cassiopeia/datastores/kernel/match.py
+++ b/cassiopeia/datastores/kernel/match.py
@@ -120,11 +120,11 @@ class MatchAPI(KernelSource):
         calling_method = determine_calling_method(begin_time, end_time)
 
         if calling_method == "by_date":
-            parameters["beginTime"] = begin_time.timestamp * 1000
+            parameters["beginTime"] = begin_time.int_timestamp * 1000
             if "endTime" in query:
-                parameters["endTime"] = min((begin_time + riot_date_interval).timestamp * 1000, query["endTime"])
+                parameters["endTime"] = min((begin_time + riot_date_interval).int_timestamp * 1000, query["endTime"])
             else:
-                parameters["endTime"] = (begin_time + riot_date_interval).timestamp * 1000
+                parameters["endTime"] = (begin_time + riot_date_interval).int_timestamp * 1000
         else:
             parameters["beginIndex"] = query["beginIndex"]
             parameters["endIndex"] = query["beginIndex"] + min(riot_index_interval, query["maxNumberOfMatches"])

--- a/cassiopeia/datastores/riotapi/match.py
+++ b/cassiopeia/datastores/riotapi/match.py
@@ -120,11 +120,11 @@ class MatchAPI(RiotAPIService):
         calling_method = determine_calling_method(begin_time, end_time)
 
         if calling_method == "by_date":
-            params["beginTime"] = begin_time.timestamp * 1000
+            params["beginTime"] = begin_time.int_timestamp * 1000
             if "endTime" in query:
-                params["endTime"] = min((begin_time + riot_date_interval).timestamp * 1000, query["endTime"])
+                params["endTime"] = min((begin_time + riot_date_interval).int_timestamp * 1000, query["endTime"])
             else:
-                params["endTime"] = (begin_time + riot_date_interval).timestamp * 1000
+                params["endTime"] = (begin_time + riot_date_interval).int_timestamp * 1000
         else:
             params["beginIndex"] = query["beginIndex"]
             params["endIndex"] = query["beginIndex"] + min(riot_index_interval, query["maxNumberOfMatches"])

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -3,7 +3,7 @@ pytest
 merakicommons>=1.0.7
 datapipelines>=1.0.7
 Pillow
-arrow<1.0.0
+arrow
 requests
 cassiopeia_championgg
 cassiopeia_diskstore

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pytest
 merakicommons>=1.0.7
 datapipelines>=1.0.7
 Pillow
-arrow<1.0.0
+arrow
 requests


### PR DESCRIPTION
Closes #361 
Other instances of timestamp usage seem to be on datetime objects and not arrow objects, unaffected by the need to replace by int_timestamp property.
Other breaking changes from Arrow 1.0.0 are not affecting Cassiopeia

This is my first open-source contribution, I hope I didn't miss anything, timeline data seems to work correctly after tests, cumulative_timeline too and so does the skill order.