### PR TITLE
`rune.path.image_url` correction

### DIFF
--- a/cassiopeia/core/staticdata/rune.py
+++ b/cassiopeia/core/staticdata/rune.py
@@ -72,7 +72,7 @@ class RunePath(CassiopeiaObject):
 
     @property
     def image_url(self):
-        url = "https://ddragon.leagueoflegends.com/cdn/img/perk-images/" + self._data[RunePathData].icon
+        url = "https://ddragon.leagueoflegends.com/cdn/img/" + self._data[RunePathData].icon
         return url
 
 


### PR DESCRIPTION
Prior to this change `cassiopeia.core.match.Participant.runes[X].path.image_url` contained a superfluous `"/perk-images"` that prevented it from working.

For example, here is `...rune.path.image_url` compared to `...rune.image.url` previously, for verification of the latter of the two images existing or not on DDragon.
```
direct rune: https://ddragon.leagueoflegends.com/cdn/img/perk-images/Styles/Sorcery/ArcaneComet/ArcaneComet.png
rune path/tree: https://ddragon.leagueoflegends.com/cdn/img/perk-images/perk-images/Styles/7200_Domination.png
```
And after this commit:
```
direct rune: https://ddragon.leagueoflegends.com/cdn/img/perk-images/Styles/Sorcery/ArcaneComet/ArcaneComet.png
rune path/tree: https://ddragon.leagueoflegends.com/cdn/img/perk-images/Styles/7200_Domination.png
```

---

Given this, would it now be possible to include a `...rune.path.image` alternative to `...rune.path.image_url`? (eg the full PIL image instead of fetching the image outside of cassiopeia)