### PR TITLE
Added new platforms

### DIFF
--- a/cassiopeia/data.py
+++ b/cassiopeia/data.py
@@ -165,7 +165,6 @@ DEFAULT_LOCALE = {
     Platform.taiwan: "zh_TW",
     Region.vietnam: "vn_VN",
     Platform.vietnam: "vn_VN",
-    
 }
 
 

--- a/cassiopeia/data.py
+++ b/cassiopeia/data.py
@@ -14,6 +14,11 @@ class Region(Enum):
     oceania = "OCE"
     turkey = "TR"
     russia = "RU"
+    philippines = "PH"
+    singapore = "SG"
+    thailand = "TH"
+    taiwan = "TW"
+    vietnam = "VN"
 
     @property
     def platform(self) -> "Platform":
@@ -44,6 +49,12 @@ class Region(Enum):
             "KR": "GMT+6",
             "JP": "GMT+7",
             "OCE": "GMT+8",
+            "PH": "GMT+8",
+            "SG": "GMT+8",
+            "TH": "GMT+7",
+            "TW": "GMT+8",
+            "VN": "GMT+7",
+
         }
         return tzs[self.value]
 
@@ -71,6 +82,16 @@ class Region(Enum):
             return Continent.europe
         if self is Region.russia:
             return Continent.europe
+        if self is Region.philippines:
+            return Continent.sea
+        if self is Region.singapore:
+            return Continent.sea
+        if self is Region.thailand:
+            return Continent.sea
+        if self is Region.taiwan:
+            return Continent.sea
+        if self is Region.vietnam:
+            return Continent.sea
 
 
 class Platform(Enum):
@@ -85,6 +106,11 @@ class Platform(Enum):
     oceania = "OC1"
     turkey = "TR1"
     russia = "RU"
+    philippines = "PH2"
+    singapore = "SG2"
+    thailand = "TH2"
+    taiwan = "TW2"
+    vietnam = "VN2"
 
     @property
     def region(self) -> "Region":
@@ -129,6 +155,17 @@ DEFAULT_LOCALE = {
     Platform.turkey: "tr_TR",
     Region.russia: "ru_RU",
     Platform.russia: "ru_RU",
+    Region.philippines: "en_PH",
+    Platform.philippines: "en_PH",
+    Region.singapore: "en_SG",
+    Platform.singapore: "en_SG",
+    Region.thailand: "en_TH",
+    Platform.thailand: "en_TH",
+    Region.taiwan: "zh_TW",
+    Platform.taiwan: "zh_TW",
+    Region.vietnam: "vn_VN",
+    Platform.vietnam: "vn_VN",
+    
 }
 
 


### PR DESCRIPTION
Here is a PR incase there is no deeper reason why the new  platforms where not added #439

But I'm not sure if the DEFAULT_LOCALE is set right.
```py
    Region.philippines: "en_PH",
    Platform.philippines: "en_PH",
    Region.singapore: "en_SG",
    Platform.singapore: "en_SG",
    Region.thailand: "en_TH",
    Platform.thailand: "en_TH",
    Region.taiwan: "zh_TW",
    Platform.taiwan: "zh_TW",
    Region.vietnam: "vn_VN",
    Platform.vietnam: "vn_VN",
```