### PR TITLE
ParticipantStats was attempting to access data by TeamData key, and some enum changes

### DIFF
--- a/cassiopeia/core/match.py
+++ b/cassiopeia/core/match.py
@@ -1208,7 +1208,7 @@ class ParticipantStats(CassiopeiaObject):
     @property
     @load_match_on_attributeerror
     def champion_experience(self) -> int:
-        return self._data[ParticipantStatsData].championExperience
+        return self._data[ParticipantStatsData].champExperience
 
     @property
     @load_match_on_attributeerror

--- a/cassiopeia/core/match.py
+++ b/cassiopeia/core/match.py
@@ -1203,12 +1203,12 @@ class ParticipantStats(CassiopeiaObject):
     @property
     @load_match_on_attributeerror
     def bounty_level(self) -> int:
-        return self._data[TeamData].bountyLevel
+        return self._data[ParticipantStatsData].bountyLevel
 
     @property
     @load_match_on_attributeerror
     def champion_experience(self) -> int:
-        return self._data[TeamData].championExperience
+        return self._data[ParticipantStatsData].championExperience
 
     @property
     @load_match_on_attributeerror
@@ -1218,7 +1218,7 @@ class ParticipantStats(CassiopeiaObject):
     @load_match_on_attributeerror
     @property
     def champion_transform(self) -> int:
-        return self._data[TeamData].championTransform
+        return self._data[ParticipantStatsData].championTransform
 
     @property
     @load_match_on_attributeerror

--- a/cassiopeia/data.py
+++ b/cassiopeia/data.py
@@ -363,6 +363,9 @@ class Lane(Enum):
             "TOP": Lane.top_lane,
             "JUNGLE": Lane.jungle,
             "UTILITY": Lane.utility,
+            "INVALID": None,
+            "Invalid": None,
+            "": None,
             "NONE": None,
         }[string]
 
@@ -373,6 +376,8 @@ class Role(Enum):
     duo_support = "DUO_SUPPORT"
     none = "NONE"
     solo = "SOLO"
+    carry = "CARRY"
+    support = "SUPPORT"    
 
     def from_match_naming_scheme(string: str):
         return {
@@ -381,6 +386,8 @@ class Role(Enum):
             "DUO_SUPPORT": Role.duo_support,
             "NONE": Role.none,
             "SOLO": Role.solo,
+            "CARRY": Role.carry,
+            "SUPPORT": Role.support,        
         }[string]
 
 

--- a/cassiopeia/data.py
+++ b/cassiopeia/data.py
@@ -236,6 +236,7 @@ class GameMode(Enum):
     nexus_blitz = "NEXUSBLITZ"
     odyssey = "ODYSSEY"
     utlbook = "ULTBOOK"
+    cherry = "CHERRY"
 
 
 class MasteryTree(Enum):


### PR DESCRIPTION
Hi, I came across some exceptions when trying to access some match data. It seems that some of the properties inside of ParticipantStats were referring to TeamData, which seems like a typo because that data is accessible via ParticipantStatsData. Additionally, some of the enums could not be parsed correctly until I added them to the dictionaries. 