### PR TITLE
fix: championmastery API by migrating to PUUID endpoints (singular)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/cassiopeia/core/championmastery.py
+++ b/cassiopeia/core/championmastery.py
@@ -63,13 +63,18 @@ class ChampionMasteries(CassiopeiaLazyList):
         query = {"region": region}
         if isinstance(summoner, Summoner):
             query["summoner.id"] = summoner.id
+            query["puuid"] = summoner.puuid
         elif isinstance(summoner, str):
             if len(summoner) < 35:
                 # It's a summoner name
-                query["summoner.id"] = Summoner(name=summoner, region=region).id
+                summoner = Summoner(name=summoner, region=region)
+                query["summoner.id"] = summoner.id
+                query["puuid"] = summoner.puuid
             else:
-                # It's probably a summoner id
-                query["summoner.id"] = summoner
+                # It's probably a summoner id, still need puuid
+                summoner = Summoner(id=summoner, region=region)
+                query["summoner.id"] = summoner.id
+                query["puuid"] = summoner.puuid
         return query
 
     @lazy_property
@@ -169,6 +174,7 @@ class ChampionMastery(CassiopeiaGhost):
         return {
             "region": self.region,
             "platform": self.platform.value,
+            "puuid": self.summoner.puuid,
             "summoner.id": self.summoner.id,
             "champion.id": self.champion.id,
         }

--- a/cassiopeia/datastores/riotapi/championmastery.py
+++ b/cassiopeia/datastores/riotapi/championmastery.py
@@ -43,6 +43,8 @@ class ChampionMasteryAPI(RiotAPIService):
         .as_(Platform)
         .also.has("summoner.id")
         .as_(str)
+        .also.has('puuid')
+        .as_(str)
         .also.has("champion.id")
         .as_(int)
     )
@@ -52,14 +54,14 @@ class ChampionMasteryAPI(RiotAPIService):
     def get_champion_mastery(
         self, query: MutableMapping[str, Any], context: PipelineContext = None
     ) -> ChampionMasteryDto:
-        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-summoner/{summonerId}/by-champion/{championId}".format(
+        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-puuid/{puuid}/by-champion/{championId}".format(
             platform=query["platform"].value.lower(),
-            summonerId=query["summoner.id"],
+            puuid=query["puuid"],
             championId=query["champion.id"],
         )
         try:
             endpoint = (
-                "champion-masteries/by-summoner/summonerId/by-champion/championId"
+                "champion-masteries/by-puuid/puuid/by-champion/championId"
             )
             app_limiter, method_limiter = self._get_rate_limiter(
                 query["platform"], endpoint
@@ -79,6 +81,8 @@ class ChampionMasteryAPI(RiotAPIService):
         .as_(Platform)
         .also.has("summonerId")
         .as_(str)
+        .also.has("puuid")
+        .as_(str)
         .also.has("championIds")
         .as_(Iterable)
     )
@@ -90,11 +94,11 @@ class ChampionMasteryAPI(RiotAPIService):
     def get_many_champion_mastery(
         self, query: MutableMapping[str, Any], context: PipelineContext = None
     ) -> Generator[ChampionMasteryDto, None, None]:
-        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-summoner/{summonerId}".format(
-            platform=query["platform"].value.lower(), summonerId=query["summonerId"]
+        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-puuid/{puuid}".format(
+            platform=query["platform"].value.lower(), puuid=query["puuid"]
         )
         try:
-            endpoint = "champion-masteries/by-summoner/summonerId"
+            endpoint = "champion-masteries/by-puuid/puuid"
             app_limiter, method_limiter = self._get_rate_limiter(
                 query["platform"], endpoint
             )
@@ -134,11 +138,11 @@ class ChampionMasteryAPI(RiotAPIService):
     def get_champion_mastery_list(
         self, query: MutableMapping[str, Any], context: PipelineContext = None
     ) -> ChampionMasteryListDto:
-        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-summoner/{summonerId}".format(
-            platform=query["platform"].value.lower(), summonerId=query["summoner.id"]
+        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/champion-masteries/by-puuid/{puuid}".format(
+            platform=query["platform"].value.lower(), puuid=query["puuid"]
         )
         try:
-            endpoint = "champion-masteries/by-summoner/summonerId"
+            endpoint = "champion-masteries/by-puuid/puuid"
             app_limiter, method_limiter = self._get_rate_limiter(
                 query["platform"], endpoint
             )
@@ -196,7 +200,7 @@ class ChampionMasteryAPI(RiotAPIService):
         return generator()
 
     _validate_get_champion_mastery_score_query = (
-        Query.has("platform").as_(Platform).also.has("summoner.id").as_(str)
+        Query.has("platform").as_(Platform).also.has("summoner.id").as_(str).also.has("puuid").as_(str)
     )
 
     @get.register(ChampionMasteryScoreDto)
@@ -206,11 +210,11 @@ class ChampionMasteryAPI(RiotAPIService):
     def get_champion_mastery_score(
         self, query: MutableMapping[str, Any], context: PipelineContext = None
     ) -> ChampionMasteryScoreDto:
-        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/scores/by-summoner/{summonerId}".format(
-            platform=query["platform"].value.lower(), summonerId=query["summoner.id"]
+        url = "https://{platform}.api.riotgames.com/lol/champion-mastery/v4/scores/by-puuid/{puuid}".format(
+            platform=query["platform"].value.lower(), puuid=query["puuid"]
         )
         try:
-            endpoint = "scores/by-summoner/summonerId"
+            endpoint = "scores/by-puuid/puuid"
             app_limiter, method_limiter = self._get_rate_limiter(
                 query["platform"], endpoint
             )


### PR DESCRIPTION
Fixed championmastery API by migrating to PUUID endpoints because summonerID endpoints are deprecated and removed by Riot.

This pull request only fixed the issues involving a singular summoner, as I couldn't test the other functions involving multiple summoners because I couldn't find any reference to them in the codebase and I can't be sure the "puuid" is being passed to the query used to send the API request, same goes for champion_mastery_score

If one of the maintainers could provide some clarity on how data are passed down to the functions that involve many summoners, I could start working on them right away.

Note: I have added "venv/" to gitignore