### PR TITLE
exclude stat shards from is_keystone(), add more rune examples

### DIFF
--- a/cassiopeia/core/staticdata/rune.py
+++ b/cassiopeia/core/staticdata/rune.py
@@ -316,7 +316,16 @@ class Rune(CassiopeiaGhost):
 
     @property
     def is_keystone(self) -> bool:
-        return self.tier == 0
+        excluded_ids = {
+            5001,
+            5002,
+            5003,
+            5005,
+            5007,
+            5008,
+        }  # These are the ids of the stat shard runes which have a tier of 0 but are not keystones
+        # alternatively, we could add tier values to the hardcoded stat runes in datastores/ddragon.py
+        return self.tier == 0 and self.id not in excluded_ids
 
     @CassiopeiaGhost.property(RuneData)
     @ghost_load_on

--- a/examples/rune.py
+++ b/examples/rune.py
@@ -3,9 +3,24 @@ from cassiopeia import Runes, Rune
 
 
 def print_keystone_runes():
+    print("Keystone runes:")
     for rune in cass.get_runes(region="NA").keystones:
         print(rune.name)
 
 
+def print_runes():
+    print("All runes:")
+    for rune in cass.get_runes(region="NA"):
+        print(f"{rune.name} id: {rune.id} tier: {rune.tier}")
+
+
+def print_precision_runes():
+    print("Precision runes:")
+    for rune in cass.get_runes(region="NA").precision:
+        print(rune.name, rune.id, rune.path.name)
+
+
 if __name__ == "__main__":
     print_keystone_runes()
+    print_runes()
+    print_precision_runes()


### PR DESCRIPTION
I noticed that stat shards were included in the output when I ran `print_keystone_runes()' in `examples/rune.py`. After digging into it, I am guessing that the hardcoded stat shards (https://github.com/meraki-analytics/cassiopeia/issues/297) do not have a .tier field, which gets defaulted to 0. To fix this, I added a set of excluded rune.id's.

I also added a couple more examples and would like to contribute more to `examples/`!

The new output is:

> `**Keystone runes:
> Making call: https://ddragon.leagueoflegends.com/realms/na.json
> Making call: https://ddragon.leagueoflegends.com/cdn/14.3.1/data/en_US/runesReforged.json
> Electrocute
> Predator
> Dark Harvest
> Hail of Blades
> Glacial Augment
> Unsealed Spellbook
> First Strike
> Press the Attack
> Lethal Tempo
> Fleet Footwork
> Conqueror
> Grasp of the Undying
> Aftershock
> Guardian
> Summon Aery
> Arcane Comet
> Phase Rush**

> All runes:
> Electrocute id: 8112 tier: 0
> Predator id: 8124 tier: 0
> Dark Harvest id: 8128 tier: 0
> Hail of Blades id: 9923 tier: 0
> Cheap Shot id: 8126 tier: 1
> Taste of Blood id: 8139 tier: 1
> Sudden Impact id: 8143 tier: 1
> ...