### PR TITLE
fix get_champion_releases() scraping

### DIFF
--- a/cassiopeia/datastores/lolwikia.py
+++ b/cassiopeia/datastores/lolwikia.py
@@ -92,12 +92,18 @@ class LolWikia(DataSource):
                 "http://leagueoflegends.wikia.com/wiki/List_of_champions"
             )
             soup = BeautifulSoup(page.text, "html.parser")
-            table = soup.find_all("table", {"class": "wikitable"})[1]
 
+            table = soup.find_all(name="table", attrs={"class": "article-table"})[0]
             rows = table.find_all("tr")[1:]
             for i, row in enumerate(rows):
-                row = [r.text.strip() for r in row.find_all("td")]
-                row = [str(row[0]), row[3]]
+                row = [
+                    r.get_text(strip=True, separator="\n").splitlines()
+                    for r in row.find_all("td")
+                ]
+                row = [
+                    str(row[0][0]),
+                    row[2][0],
+                ]  # [0][0] to get the champion name without title. e.g. "Aatrox" instead of "Aatrox, the Darkin Blade"
                 try:
                     row[0] = row[0][: row[0].index("\xa0")]
                 except ValueError:

--- a/cassiopeia/datastores/lolwikia.py
+++ b/cassiopeia/datastores/lolwikia.py
@@ -104,14 +104,6 @@ class LolWikia(DataSource):
                     str(row[0][0]),
                     row[2][0],
                 ]  # [0][0] to get the champion name without title. e.g. "Aatrox" instead of "Aatrox, the Darkin Blade"
-                try:
-                    row[0] = row[0][: row[0].index("\xa0")]
-                except ValueError:
-                    pass
-                try:
-                    row[0] = row[0][: row[0].index(",")]
-                except ValueError:
-                    pass
                 row[1] = arrow.get(row[1])
                 rows[i] = row
 


### PR DESCRIPTION
## Summary
The `test/test_champion.py::test_release_dates` test fails due to `cassiopeia/datastores/lolwikia.py`'s scraping of "http://leagueoflegends.wikia.com/wiki/List_of_champions". I think the wikia table format has changed over the years, so I updated `get_champion_releases()` to work on the current page.

**before change:**
```
❯ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
❯ pytest test/test_champion.py --quiet --tb=line
....F                                                                                                                                                          [100%]
============================================================================== FAILURES ==============================================================================
/Users/stephen/Github/cassiopeia/cassiopeia/datastores/lolwikia.py:95: IndexError: list index out of range
========================================================================== warnings summary ==========================================================================
../../Library/Python/3.12/lib/python/site-packages/dateutil/tz/tz.py:37
  /Users/stephen/Library/Python/3.12/lib/python/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================== short test summary info =======================================================================
FAILED test/test_champion.py::test_release_dates - IndexError: list index out of range
1 failed, 4 passed, 1 warning in 0.83s
```

**after change:**
```
❯ git switch tests
Switched to branch 'tests'
Your branch is up to date with 'origin/tests'.
❯ pytest test/test_champion.py --quiet --tb=line
.....                                                                                                                                                          [100%]
========================================================================== warnings summary ==========================================================================
../../Library/Python/3.12/lib/python/site-packages/dateutil/tz/tz.py:37
  /Users/stephen/Library/Python/3.12/lib/python/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
5 passed, 1 warning in 1.24s
```