### PR TITLE
Fix crash when loading accounts

### DIFF
--- a/cassiopeia/datastores/riotapi/account.py
+++ b/cassiopeia/datastores/riotapi/account.py
@@ -80,8 +80,10 @@ class AccountAPI(RiotAPIService):
             app_limiter, method_limiter = self._get_rate_limiter(
                 query["platform"], endpoint
             )
-            data = self._get(
-                url, {}, app_limiter=app_limiter, method_limiter=method_limiter
+            data = json.loads(
+                self._get(
+                    url, {}, app_limiter=app_limiter, method_limiter=method_limiter
+                )
             )
         except APINotFoundError as error:
             raise NotFoundError(str(error)) from error


### PR DESCRIPTION
This would previously fail with the following error:

      File ".../cassiopeia/datastores/riotapi/account.py", line 89, in get_account
        data["region"] = query["platform"].region.value
        ~~~~^^^^^^^^^^
    TypeError: 'str' object does not support item assignment